### PR TITLE
Add scoped local multi-session overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Use a scoped override when you want one local lane pinned differently from the g
 For HTTP requests:
 
 ```http
-x-llm-switch-session: gpt-work
+x-llm-session: gpt-work
 ```
 
 For Codex WebSocket connections:
@@ -220,6 +220,8 @@ For Codex WebSocket connections:
 ```
 
 If no scoped session is provided, the proxy uses the current global active session.
+
+`x-llm-switch-session` is still accepted as a compatibility alias, but `x-llm-session` is the preferred header going forward.
 
 ## Architecture
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -224,7 +224,7 @@ The proxy now has two session-selection modes:
 
 Scoped selection currently works as follows:
 
-- **HTTP**: `x-llm-switch-session: <name>`
+- **HTTP**: `x-llm-session: <name>` (preferred; `x-llm-switch-session` remains a compatibility alias)
 - **WebSocket**: `/responses?session=<name>`
 
 Semantics:

--- a/docs/multi-session-design.md
+++ b/docs/multi-session-design.md
@@ -162,7 +162,7 @@ Use the **hybrid model**.
 
 For the first iteration:
 
-- **HTTP**: allow a request header such as `x-llm-switch-session: <name>`
+- **HTTP**: allow a request header such as `x-llm-session: <name>` (with `x-llm-switch-session` kept as a compatibility alias)
 - **WebSocket**: allow a query parameter such as `/responses?session=<name>`
 
 Why this shape:
@@ -191,7 +191,8 @@ This avoids surprising mid-connection backend flips.
 The first MVP slice is now implemented:
 
 - global active session remains the default
-- HTTP supports `x-llm-switch-session`
+- HTTP supports `x-llm-session`
+- `x-llm-switch-session` remains accepted as a compatibility alias
 - WebSocket `/responses` supports `?session=<name>`
 
 This solves the most basic local parallel-session problem without changing the default UX.

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -467,7 +467,7 @@ describe("proxy HTTP routes", () => {
     });
   });
 
-  it("uses x-llm-switch-session to override the global session for /v1/models", async () => {
+  it("uses x-llm-session to override the global session for /v1/models", async () => {
     const fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
     const proxy = createProxyServer({
       fetchImpl: async (url, init) => {
@@ -503,7 +503,7 @@ describe("proxy HTTP routes", () => {
       });
 
       const res = await request(baseUrl, "/v1/models", {
-        headers: { "x-llm-switch-session": "gpt-work" },
+        headers: { "x-llm-session": "gpt-work" },
       });
 
       assert.equal(res.status, 200);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -91,7 +91,7 @@ function getScopedSession(name: string | null | undefined) {
 }
 
 function getRequestedSessionName(req: IncomingMessage): string | null {
-  const header = req.headers["x-llm-switch-session"];
+  const header = req.headers["x-llm-session"] ?? req.headers["x-llm-switch-session"];
   if (typeof header === "string" && header.trim()) return header.trim();
   return null;
 }


### PR DESCRIPTION
## Summary
- add scoped session overrides on top of the global active-session model
- prefer x-llm-session for HTTP while keeping x-llm-switch-session as a compatibility alias
- document the session-selection model and cover it with regression tests

## Testing
- npm run test

Closes #1