### PR TITLE
Add observability for scoped session routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,14 @@ If no scoped session is provided, the proxy uses the current global active sessi
 
 `x-llm-switch-session` is still accepted as a compatibility alias, but `x-llm-session` is the preferred header going forward.
 
+For proxied HTTP requests, the response includes:
+
+```http
+x-llm-session-used: <session-name>
+```
+
+This makes it easy to verify which session actually handled a request when you are using scoped overrides.
+
 ## Architecture
 
 At a high level:

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -200,6 +200,7 @@ describe("proxy HTTP routes", () => {
       });
 
       assert.equal(res.status, 200);
+      assert.equal(res.headers.get("x-llm-session-used"), "claude-work");
       assert.equal(fetchCalls.length, 1);
       assert.equal(fetchCalls[0].url, "https://example.anthropic.test/v1/messages");
       const body = JSON.parse(String(fetchCalls[0].init?.body));
@@ -245,6 +246,7 @@ describe("proxy HTTP routes", () => {
       });
 
       assert.equal(res.status, 200);
+      assert.equal(res.headers.get("x-llm-session-used"), "claude-oauth");
       assert.equal(fetchCalls.length, 1);
       assert.equal(fetchCalls[0].url, "https://oauth.example.test/v1/messages");
 
@@ -329,6 +331,7 @@ describe("proxy HTTP routes", () => {
         });
 
         assert.equal(res.status, 200);
+        assert.equal(res.headers.get("x-llm-session-used"), "gpt-work");
         const body = JSON.parse(res.text);
         assert.equal(body.content[0].text, "from override session");
       });
@@ -407,6 +410,7 @@ describe("proxy HTTP routes", () => {
         });
 
         assert.equal(res.status, 200);
+        assert.equal(res.headers.get("x-llm-session-used"), "gpt-work");
         const body = JSON.parse(res.text);
         assert.equal(body.content[0].text, "from alias header");
       });
@@ -460,6 +464,7 @@ describe("proxy HTTP routes", () => {
 
       const res = await request(baseUrl, "/v1/models?limit=1");
       assert.equal(res.status, 200);
+      assert.equal(res.headers.get("x-llm-session-used"), "gpt-work");
       assert.equal(fetchCalls.length, 1);
       assert.equal(fetchCalls[0].url, "https://models.example.test/v1/models?limit=1");
       const body = JSON.parse(res.text);
@@ -507,6 +512,7 @@ describe("proxy HTTP routes", () => {
       });
 
       assert.equal(res.status, 200);
+      assert.equal(res.headers.get("x-llm-session-used"), "gpt-work");
       assert.equal(fetchCalls.length, 1);
       assert.equal(fetchCalls[0].url, "https://models.example.test/v1/models");
     });
@@ -650,6 +656,7 @@ describe("proxy HTTP routes", () => {
 
         assert.equal(res.status, 200);
         assert.equal(res.headers.get("content-type"), "text/event-stream");
+        assert.equal(res.headers.get("x-llm-session-used"), "gpt-work");
         const text = await res.text();
         assert.match(text, /event: message_start/);
         assert.match(text, /event: content_block_start/);
@@ -750,6 +757,9 @@ describe("proxy admin routes", () => {
       assert.equal(beforeBody.active_session.name, "claude-work");
       assert.equal(beforeBody.active_session.provider, "anthropic");
       assert.equal(beforeBody.active_session.token, undefined);
+      assert.deepEqual(beforeBody.available_sessions, ["claude-work", "gpt-work"]);
+      assert.equal(beforeBody.override_header, "x-llm-session");
+      assert.equal(beforeBody.override_ws_param, "?session=<name>");
 
       const switchRes = await request(baseUrl, "/admin/switch/gpt-work", {
         method: "POST",
@@ -762,6 +772,9 @@ describe("proxy admin routes", () => {
       assert.equal(afterBody.active_session.name, "gpt-work");
       assert.equal(afterBody.active_session.provider, "openai");
       assert.equal(afterBody.active_session.token, undefined);
+      assert.deepEqual(afterBody.available_sessions, ["claude-work", "gpt-work"]);
+      assert.equal(afterBody.override_header, "x-llm-session");
+      assert.equal(afterBody.override_ws_param, "?session=<name>");
 
       const removeRes = await request(baseUrl, "/admin/sessions/gpt-work", {
         method: "DELETE",
@@ -785,6 +798,19 @@ describe("proxy admin routes", () => {
 
       assert.equal(res.status, 422);
       assert.match(res.text, /required/);
+    });
+  });
+
+  it("reports observability hints even when no active session exists", async () => {
+    await withServer(async (baseUrl) => {
+      const res = await request(baseUrl, "/admin/status");
+      assert.equal(res.status, 200);
+      const body = JSON.parse(res.text);
+      assert.equal(body.active_session, null);
+      assert.deepEqual(body.available_sessions, []);
+      assert.equal(body.override_header, "x-llm-session");
+      assert.equal(body.override_ws_param, "?session=<name>");
+      assert.deepEqual(body.rate_limits, {});
     });
   });
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -14,6 +14,10 @@ interface ProxyDeps {
   codexBridgeUrl?: string;
 }
 
+function sessionUsedHeader(sessionName: string): Record<string, string> {
+  return { "x-llm-session-used": sessionName };
+}
+
 // --- OAuth helpers ---
 
 const BILLING_BLOCK = {
@@ -178,6 +182,7 @@ async function handleProxy(
         "content-type": "text/event-stream",
         "cache-control": "no-cache",
         "connection": "keep-alive",
+        ...sessionUsedHeader(session.name),
       });
       const reader = upstreamRes.body.getReader();
       const decoder = new TextDecoder();
@@ -190,11 +195,17 @@ async function handleProxy(
     } else {
       // JSON passthrough
       const responseBody = await upstreamRes.text();
-      res.writeHead(upstreamRes.status, { "content-type": "application/json" });
+      res.writeHead(upstreamRes.status, {
+        "content-type": "application/json",
+        ...sessionUsedHeader(session.name),
+      });
       res.end(responseBody);
     }
   } catch (err: any) {
-    res.writeHead(502, { "content-type": "application/json" });
+    res.writeHead(502, {
+      "content-type": "application/json",
+      ...sessionUsedHeader(session.name),
+    });
     res.end(JSON.stringify({ error: { type: "upstream_connection_error", message: err.message } }));
   }
 }
@@ -228,7 +239,10 @@ async function handleOpenAIProxy(
   function endResponse(status: number, body: any): void {
     if (responseDone) return;
     responseDone = true;
-    res.writeHead(status, { "content-type": "application/json" });
+    res.writeHead(status, {
+      "content-type": "application/json",
+      ...sessionUsedHeader(session.name),
+    });
     res.end(JSON.stringify(body));
   }
 
@@ -239,6 +253,7 @@ async function handleOpenAIProxy(
         "content-type": "text/event-stream",
         "cache-control": "no-cache",
         "connection": "keep-alive",
+        ...sessionUsedHeader(session.name),
       });
     }
     res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
@@ -322,10 +337,16 @@ async function handleModels(
   try {
     const upstreamRes = await deps.fetchImpl(url, { headers });
     const body = await upstreamRes.text();
-    res.writeHead(upstreamRes.status, { "content-type": "application/json" });
+    res.writeHead(upstreamRes.status, {
+      "content-type": "application/json",
+      ...sessionUsedHeader(session.name),
+    });
     res.end(body);
   } catch (err: any) {
-    res.writeHead(502, { "content-type": "application/json" });
+    res.writeHead(502, {
+      "content-type": "application/json",
+      ...sessionUsedHeader(session.name),
+    });
     res.end(JSON.stringify({ error: err.message }));
   }
 }
@@ -376,13 +397,24 @@ async function handleAdmin(req: IncomingMessage, res: ServerResponse, path: stri
   // GET /admin/status
   if (req.method === "GET" && path === "/admin/status") {
     const session = getActiveSession();
+    const { sessions } = listSessions();
+    const availableSessions = Object.keys(sessions);
     if (!session) {
-      res.end(JSON.stringify({ active_session: null, rate_limits: {} }));
+      res.end(JSON.stringify({
+        active_session: null,
+        available_sessions: availableSessions,
+        override_header: "x-llm-session",
+        override_ws_param: "?session=<name>",
+        rate_limits: {},
+      }));
       return;
     }
     const { token, ...safe } = session;
     res.end(JSON.stringify({
       active_session: safe,
+      available_sessions: availableSessions,
+      override_header: "x-llm-session",
+      override_ws_param: "?session=<name>",
       rate_limits: rateLimits[session.name] || {},
     }));
     return;


### PR DESCRIPTION
## Summary
- add x-llm-session-used to proxied HTTP responses
- expand admin/status with available sessions and scoped override hints
- document how to verify which session handled a request

## Testing
- npm run test

Closes #6