### PR TITLE
Add project-local proxy statusline support

### DIFF
--- a/src/statusline.test.ts
+++ b/src/statusline.test.ts
@@ -25,7 +25,7 @@ const healthyFetch = createFetchStub({
   "/admin/status": {
     active_session: { name: "claude-default", provider: "anthropic" },
   },
-  "/admin/sessions?health=true": {
+  "/admin/sessions": {
     sessions: {
       "claude-default": {
         model_override: "claude-sonnet-4-5",
@@ -59,7 +59,7 @@ const fallbackFetch = createFetchStub({
   "/admin/status": {
     active_session: { name: "gpt-default", provider: "openai" },
   },
-  "/admin/sessions?health=true": {
+  "/admin/sessions": {
     sessions: {
       "gpt-default": {
         model_override: "gpt-4.1",
@@ -75,7 +75,7 @@ const fallbackFetch = createFetchStub({
 
 const offlineFetch = createFetchStub({
   "/admin/status": new Error("offline"),
-  "/admin/sessions?health=true": new Error("offline"),
+  "/admin/sessions": new Error("offline"),
 });
 
 describe("statusline helpers", () => {

--- a/src/statusline.ts
+++ b/src/statusline.ts
@@ -100,7 +100,7 @@ export async function fetchProxySessions(
   fetchImpl: FetchLike,
 ): Promise<Record<string, SessionAdminView>> {
   try {
-    const res = await fetchImpl(new URL("/admin/sessions?health=true", baseUrl), {
+    const res = await fetchImpl(new URL("/admin/sessions", baseUrl), {
       signal: AbortSignal.timeout(1500),
     });
     if (!res.ok) return {};


### PR DESCRIPTION
## Summary
- add project-local Claude settings helpers and `/llm-switch statusline on|off` guidance for enabling a repo-scoped statusline without touching global Claude settings
- extend `llm-switcher statusline` to render proxy session, effective model, and compact health while returning empty text for direct/non-proxy windows
- add tests covering statusline rendering, project-local settings updates, and tracked command markdown expectations

## Test plan
- [x] npm test

🤖 Generated with [Claude Code](https://claude.com/claude-code)