### PR TITLE
Auto-refresh Codex OAuth token on WS 401

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -71,8 +71,9 @@ program
     console.log(`Token found: ${token.slice(0, 20)}...`);
     console.log(`Account ID: ${accountId}`);
 
-    addSession(name, "openai", token, undefined, undefined, accountId);
-    console.log(`\u2713 Session '${name}' ready with Codex OAuth token`);
+    const refreshToken = auth.tokens.refresh_token;
+    addSession(name, "openai", token, undefined, undefined, accountId, refreshToken);
+    console.log(`\u2713 Session '${name}' ready with Codex OAuth token${refreshToken ? " (auto-refresh enabled)" : ""}`);
   });
 
 // --- add ---

--- a/src/codex.ts
+++ b/src/codex.ts
@@ -1,6 +1,58 @@
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync, existsSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
+
+const CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrannkey";
+const CODEX_TOKEN_ENDPOINT = "https://auth0.openai.com/oauth/token";
+
+export interface CodexTokenRefreshResult {
+  access_token: string;
+  refresh_token?: string;
+}
+
+export async function refreshCodexToken(
+  refreshToken: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<CodexTokenRefreshResult> {
+  const res = await fetchImpl(CODEX_TOKEN_ENDPOINT, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+      client_id: CODEX_CLIENT_ID,
+    }).toString(),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Token refresh failed: HTTP ${res.status} ${text}`);
+  }
+
+  const data = await res.json() as Record<string, unknown>;
+  if (typeof data.access_token !== "string") {
+    throw new Error("Token refresh response missing access_token");
+  }
+
+  return {
+    access_token: data.access_token,
+    ...(typeof data.refresh_token === "string" ? { refresh_token: data.refresh_token } : {}),
+  };
+}
+
+export function updateCodexAuthFile(newTokens: CodexTokenRefreshResult): void {
+  const authPath = join(homedir(), ".codex", "auth.json");
+  if (!existsSync(authPath)) return;
+  try {
+    const auth = JSON.parse(readFileSync(authPath, "utf-8"));
+    auth.tokens.access_token = newTokens.access_token;
+    if (newTokens.refresh_token) auth.tokens.refresh_token = newTokens.refresh_token;
+    auth.last_refresh = new Date().toISOString();
+    writeFileSync(authPath, JSON.stringify(auth, null, 2), { mode: 0o600 });
+  } catch {
+    // best-effort
+  }
+}
 
 export interface CodexAuth {
   auth_mode: string;

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,7 @@ export interface Session {
   base_url: string;
   model_override?: string;
   account_id?: string;
+  refresh_token?: string;
 }
 
 export interface Config {
@@ -39,6 +40,7 @@ export function addSession(
   baseUrl?: string,
   modelOverride?: string,
   accountId?: string,
+  refreshToken?: string,
 ): void {
   const config = loadConfig();
   config.sessions[name] = {
@@ -47,8 +49,16 @@ export function addSession(
     base_url: baseUrl ?? (provider === "anthropic" ? "https://api.anthropic.com" : "https://api.openai.com"),
     ...(modelOverride ? { model_override: modelOverride } : {}),
     ...(accountId ? { account_id: accountId } : {}),
+    ...(refreshToken ? { refresh_token: refreshToken } : {}),
   };
   if (!config.active_session) config.active_session = name;
+  saveConfig(config);
+}
+
+export function updateSessionToken(name: string, token: string): void {
+  const config = loadConfig();
+  if (!config.sessions[name]) throw new Error(`Session '${name}' not found`);
+  config.sessions[name].token = token;
   saveConfig(config);
 }
 

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import { createServer } from "node:http";
-import { once } from "node:events";
+import { once, EventEmitter } from "node:events";
 import { WebSocket, WebSocketServer } from "ws";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -601,6 +601,96 @@ describe("OpenAI proxy effectiveModel", () => {
         const sessionsRes = await request(baseUrl, "/admin/sessions");
         const body = JSON.parse(sessionsRes.text);
         assert.equal(body.sessions["gpt-work"].last_effective_model, "gpt-5.4");
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) => upstreamWss.close((err) => (err ? reject(err) : resolve())));
+      await new Promise<void>((resolve, reject) => upstreamServer.close((err) => (err ? reject(err) : resolve())));
+    }
+  });
+});
+
+describe("OpenAI token auto-refresh on 401", () => {
+  it("refreshes token and retries when WS returns 401", async () => {
+    const upstreamServer = createServer();
+    const upstreamWss = new WebSocketServer({ server: upstreamServer });
+
+    await once(upstreamServer.listen(0, "127.0.0.1"), "listening");
+    const addr = upstreamServer.address();
+    assert.ok(addr && typeof addr === "object");
+    const upstreamUrl = `ws://127.0.0.1:${addr.port}`;
+
+    let connectionCount = 0;
+    upstreamWss.on("connection", (ws) => {
+      connectionCount++;
+      ws.on("message", () => {
+        ws.send(JSON.stringify({
+          type: "response.completed",
+          response: {
+            id: "resp_refresh",
+            model: "gpt-5.4",
+            status: "completed",
+            output: [{ type: "message", content: [{ type: "output_text", text: "ok" }] }],
+            usage: { input_tokens: 1, output_tokens: 1 },
+          },
+        }));
+      });
+    });
+
+    let wsCallCount = 0;
+    const expiredToken = "sk-expired";
+    const freshToken = "sk-fresh";
+    let refreshCalled = false;
+
+    const proxy = createProxyServer({
+      // First WS call with expired token → simulate 401; second call with fresh token → connect to real server
+      openAIWsFactory: (_url, options) => {
+        wsCallCount++;
+        const authHeader = (options?.headers as any)?.authorization ?? "";
+        if (authHeader.includes(expiredToken)) {
+          // Return a fake WS that immediately errors with 401
+          const fake = new EventEmitter() as any;
+          fake.send = () => {};
+          fake.close = () => {};
+          setImmediate(() => fake.emit("error", Object.assign(new Error("Unexpected server response: 401"), { statusCode: 401 })));
+          return fake;
+        }
+        return new WebSocket(upstreamUrl, options);
+      },
+      fetchImpl: async (url, init) => {
+        if (String(url).includes("oauth/token")) {
+          refreshCalled = true;
+          return new Response(JSON.stringify({ access_token: freshToken, refresh_token: "rt-new" }), {
+            status: 200, headers: { "content-type": "application/json" },
+          });
+        }
+        return new Response(JSON.stringify({}), { status: 200, headers: { "content-type": "application/json" } });
+      },
+    });
+
+    try {
+      await withCustomServer(proxy, async (baseUrl) => {
+        await request(baseUrl, "/admin/sessions", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            name: "codex",
+            provider: "openai",
+            token: expiredToken,
+            model_override: "gpt-5.4",
+            refresh_token: "rt-old",
+          }),
+        });
+
+        const res = await request(baseUrl, "/v1/messages", {
+          method: "POST",
+          headers: { "content-type": "application/json", "x-llm-session": "codex" },
+          body: JSON.stringify({ stream: false, messages: [{ role: "user", content: "hi" }] }),
+        });
+
+        assert.equal(res.status, 200, "should succeed after token refresh");
+        assert.equal(refreshCalled, true, "should have called token refresh endpoint");
+        assert.equal(wsCallCount, 2, "should have made two WS connections");
+        assert.equal(connectionCount, 1, "only the second WS should reach upstream");
       });
     } finally {
       await new Promise<void>((resolve, reject) => upstreamWss.close((err) => (err ? reject(err) : resolve())));

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -139,11 +139,13 @@ interface SessionProbeStatus {
 
 const sessionObservability: Record<string, SessionObservability> = {};
 const sessionProbeStatus: Record<string, SessionProbeStatus> = {};
+const pendingTokenRefresh = new Map<string, Promise<import("./codex.js").CodexTokenRefreshResult>>();
 
 export function resetRuntimeObservability(): void {
   for (const key of Object.keys(rateLimits)) delete rateLimits[key];
   for (const key of Object.keys(sessionObservability)) delete sessionObservability[key];
   for (const key of Object.keys(sessionProbeStatus)) delete sessionProbeStatus[key];
+  pendingTokenRefresh.clear();
 }
 
 export function setProbeCheckedAtForTest(sessionName: string, checkedAt: string): void {
@@ -681,12 +683,22 @@ async function handleOpenAIProxy(
     });
 
     ws.on("error", async (err) => {
-      if (canRetry && err.message.includes("401")) {
+      const is401 = (err as any).statusCode === 401 || err.message.includes("401");
+      if (canRetry && is401) {
         const refreshToken = session.refresh_token;
         if (refreshToken) {
           console.error(`[OpenAI] Token expired, attempting refresh for session '${session.name}'`);
           try {
-            const result = await refreshCodexToken(refreshToken, deps.fetchImpl);
+            // Deduplicate concurrent refreshes: if another request already started a refresh
+            // for this session, wait for that result rather than burning the rotation token twice.
+            let refreshPromise = pendingTokenRefresh.get(session.name);
+            if (!refreshPromise) {
+              refreshPromise = refreshCodexToken(refreshToken, deps.fetchImpl).finally(() => {
+                pendingTokenRefresh.delete(session.name);
+              });
+              pendingTokenRefresh.set(session.name, refreshPromise);
+            }
+            const result = await refreshPromise;
             updateSessionToken(session.name, result.access_token);
             updateCodexAuthFile(result);
             session.token = result.access_token;
@@ -696,6 +708,10 @@ async function handleOpenAIProxy(
             return;
           } catch (refreshErr) {
             console.error(`[OpenAI] Token refresh failed:`, (refreshErr as Error).message);
+            endResponse(502, {
+              error: { type: "token_refresh_failed", message: (refreshErr as Error).message },
+            });
+            return;
           }
         }
       }
@@ -707,7 +723,7 @@ async function handleOpenAIProxy(
         type: "upstream_connection_error",
         message: err.message,
       });
-      endResponse(err.message.includes("401") ? 401 : 502, {
+      endResponse(502, {
         error: { type: "upstream_connection_error", message: err.message },
       });
     });

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,8 +1,8 @@
 import { createServer, IncomingMessage, ServerResponse } from "node:http";
 import { WebSocketServer, WebSocket as WsWebSocket } from "ws";
-import { getActiveSession, listSessions, addSession, removeSession, setActive } from "./config.js";
+import { getActiveSession, listSessions, addSession, removeSession, setActive, updateSessionToken } from "./config.js";
 import type { Session } from "./config.js";
-import { buildCodexHeaders } from "./codex.js";
+import { buildCodexHeaders, refreshCodexToken, updateCodexAuthFile } from "./codex.js";
 import { inferProviderFromModel, pickDeterministicSessionName } from "./models.js";
 import { translateRequest, translateResponse, createWsEventProcessor } from "./translate.js";
 
@@ -580,7 +580,7 @@ async function handleProxy(
 async function handleOpenAIProxy(
   res: ServerResponse,
   requestBody: any,
-  session: { name: string; token: string; model_override?: string; account_id?: string },
+  session: { name: string; token: string; model_override?: string; account_id?: string; refresh_token?: string },
   deps: Required<ProxyDeps>,
   responseHeaders: Record<string, string> = sessionUsedHeader(session.name),
   routingData: { resolvedSession?: string | null; inferredProvider?: Session["provider"] | null; resolutionReason?: RoutingReason | null } = {},
@@ -595,9 +595,7 @@ async function handleOpenAIProxy(
   }
 
   const isStream = requestBody.stream === true;
-  const ws = deps.openAIWsFactory(translated.url, { headers: translated.headers });
   let responseDone = false;
-  const processWsEvent = createWsEventProcessor();
   const requestedModel = typeof requestBody.model === "string" ? requestBody.model : null;
   const effectiveModel = typeof requestBody.model === "string" ? requestBody.model : session.model_override || null;
 
@@ -624,83 +622,111 @@ async function handleOpenAIProxy(
     res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
   }
 
-  ws.on("open", () => {
-    ws.send(JSON.stringify({ type: "response.create", ...requestBody }));
-  });
+  function connectWs(token: string, canRetry: boolean): void {
+    const headers = buildCodexHeaders(token, session.account_id || "");
+    const ws = deps.openAIWsFactory(translated.url, { headers });
+    const processWsEvent = createWsEventProcessor();
 
-  ws.on("message", (data) => {
-    let event: any;
-    try {
-      event = JSON.parse(data.toString());
-    } catch {
-      return;
-    }
+    ws.on("open", () => {
+      ws.send(JSON.stringify({ type: "response.create", ...requestBody }));
+    });
 
-    if (event.type === "error") {
-      console.error(`[OpenAI] WS error event:`, JSON.stringify(event));
-      recordSessionError(session, {
-        requestedModel,
-        effectiveModel,
-        ...routingData,
-        type: event.error?.type || "api_error",
-        message: event.error?.message || "OpenAI error",
-      });
-      endResponse(502, { error: { type: "api_error", message: event.error?.message || "OpenAI error" } });
-      ws.close();
-      return;
-    }
+    ws.on("message", (data) => {
+      let event: any;
+      try {
+        event = JSON.parse(data.toString());
+      } catch {
+        return;
+      }
 
-    if (isStream) {
-      processWsEvent(event, writeSSE);
-      if (event.type === "response.completed") {
+      if (event.type === "error") {
+        console.error(`[OpenAI] WS error event:`, JSON.stringify(event));
+        recordSessionError(session, {
+          requestedModel,
+          effectiveModel,
+          ...routingData,
+          type: event.error?.type || "api_error",
+          message: event.error?.message || "OpenAI error",
+        });
+        endResponse(502, { error: { type: "api_error", message: event.error?.message || "OpenAI error" } });
+        ws.close();
+        return;
+      }
+
+      if (isStream) {
+        processWsEvent(event, writeSSE);
+        if (event.type === "response.completed") {
+          recordSessionSuccess(session, {
+            requestedModel,
+            effectiveModel,
+            ...routingData,
+            usage: event.response?.usage || null,
+          });
+          processWsEvent({ type: "_finish" }, writeSSE);
+          responseDone = true;
+          res.end();
+          ws.close();
+        }
+      } else if (event.type === "response.completed") {
         recordSessionSuccess(session, {
           requestedModel,
           effectiveModel,
           ...routingData,
           usage: event.response?.usage || null,
         });
-        processWsEvent({ type: "_finish" }, writeSSE);
-        responseDone = true;
-        res.end();
+        const anthropicRes = translateResponse(event.response);
+        endResponse(200, anthropicRes);
         ws.close();
       }
-    } else if (event.type === "response.completed") {
-      recordSessionSuccess(session, {
-        requestedModel,
-        effectiveModel,
-        ...routingData,
-        usage: event.response?.usage || null,
-      });
-      const anthropicRes = translateResponse(event.response);
-      endResponse(200, anthropicRes);
-      ws.close();
-    }
-  });
-
-  ws.on("error", (err) => {
-    console.error(`[OpenAI] WS connection error:`, err.message);
-    recordSessionError(session, {
-      requestedModel,
-      effectiveModel,
-      ...routingData,
-      type: "upstream_connection_error",
-      message: err.message,
     });
-    endResponse(502, { error: { type: "upstream_connection_error", message: err.message } });
-  });
 
-  ws.on("close", (code) => {
-    if (!responseDone && code !== 1000) {
+    ws.on("error", async (err) => {
+      if (canRetry && err.message.includes("401")) {
+        const refreshToken = session.refresh_token;
+        if (refreshToken) {
+          console.error(`[OpenAI] Token expired, attempting refresh for session '${session.name}'`);
+          try {
+            const result = await refreshCodexToken(refreshToken, deps.fetchImpl);
+            updateSessionToken(session.name, result.access_token);
+            updateCodexAuthFile(result);
+            session.token = result.access_token;
+            if (result.refresh_token) session.refresh_token = result.refresh_token;
+            console.error(`[OpenAI] Token refreshed, retrying`);
+            connectWs(result.access_token, false);
+            return;
+          } catch (refreshErr) {
+            console.error(`[OpenAI] Token refresh failed:`, (refreshErr as Error).message);
+          }
+        }
+      }
+      console.error(`[OpenAI] WS connection error:`, err.message);
       recordSessionError(session, {
         requestedModel,
         effectiveModel,
         ...routingData,
-        type: "upstream_closed",
-        message: `Upstream WebSocket closed unexpectedly (${code})`,
+        type: "upstream_connection_error",
+        message: err.message,
       });
-      endResponse(502, { error: { type: "upstream_closed", message: `Upstream WebSocket closed unexpectedly (${code})` } });
-    }
-  });
+      endResponse(err.message.includes("401") ? 401 : 502, {
+        error: { type: "upstream_connection_error", message: err.message },
+      });
+    });
+
+    ws.on("close", (code) => {
+      if (!responseDone && code !== 1000) {
+        recordSessionError(session, {
+          requestedModel,
+          effectiveModel,
+          ...routingData,
+          type: "upstream_closed",
+          message: `Upstream WebSocket closed unexpectedly (${code})`,
+        });
+        endResponse(502, { error: { type: "upstream_closed", message: `Upstream WebSocket closed unexpectedly (${code})` } });
+      }
+    });
+  }
+
+  connectWs(session.token, true);
 }
 
 async function handleModels(
@@ -962,7 +988,7 @@ async function handleAdmin(
       res.end(JSON.stringify({ error: { type: "invalid_request", message: "name, provider, and token are required" } }));
       return;
     }
-    addSession(body.name, body.provider, body.token, body.base_url, body.model_override, body.account_id);
+    addSession(body.name, body.provider, body.token, body.base_url, body.model_override, body.account_id, body.refresh_token);
     res.writeHead(201, { "content-type": "application/json" });
     res.end(JSON.stringify({ ok: true }));
     return;


### PR DESCRIPTION
## Summary

- When Codex's `access_token` expires, the WebSocket handshake fails with HTTP 401. Previously this surfaced as an unrecoverable `[OpenAI] WS connection error: 401` and the request failed.
- This PR detects the 401, calls the Auth0 token endpoint once using the stored `refresh_token`, updates `config.json` and `~/.codex/auth.json` with the new tokens, then retries the WS connection with the fresh token — all transparently within the same request.

### Changes

- **`src/codex.ts`**: Add `refreshCodexToken()` (calls Auth0 refresh endpoint) and `updateCodexAuthFile()` (writes updated tokens back to `~/.codex/auth.json`)
- **`src/config.ts`**: Add `refresh_token?: string` to `Session` interface; add `updateSessionToken()` helper; extend `addSession()` with optional `refreshToken` param
- **`src/cli.ts`**: `codex-login` now stores `refresh_token` when importing from `~/.codex/auth.json`
- **`src/proxy.ts`**: Refactor `handleOpenAIProxy` with inner `connectWs(token, canRetry)` — on 401 WS error with `canRetry=true`, refresh token and retry once with `canRetry=false`. Also fix `/admin/sessions` POST to forward `refresh_token` field to `addSession`.

## Test plan

- [x] `npm test` — 18/18 pass including new test "refreshes token and retries when WS returns 401"
- [x] Test covers: fake WS factory emits 401 for expired token → `fetchImpl` returns fresh token → real upstream WS receives second connection → response status 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)