### PR TITLE
Prioritize active session over provider inference

### DIFF
--- a/docs/lane-design.md
+++ b/docs/lane-design.md
@@ -65,10 +65,10 @@ Instead, phase 1 should route Claude Code requests using the only per-request di
 Recommended phase-1 behavior:
 
 1. keep explicit `x-llm-session` as the highest-priority override
-2. if no explicit session override exists, inspect `body.model`
-3. infer provider from built-in model/provider mapping when possible
-4. resolve a compatible session from the configured session pool
-5. if no model-based match exists, fall back to existing per-chat binding or global active session behavior
+2. if no explicit session override exists, inspect `body.model` for exact `model_override` or session-name matches
+3. if no exact model-based match exists, prefer the current global active session
+4. if there is no active session, fall back to existing per-chat binding
+5. only then infer provider from built-in model/provider mapping and resolve a compatible session from the configured session pool
 6. keep this deterministic and avoid health-based failover in the first step
 
 This is not true lane identity. It is a request-scoped routing step that approximates stable subagent routing when a subagent keeps the same model for its lifetime.

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -439,7 +439,69 @@ describe("proxy HTTP routes", () => {
     });
   });
 
-  it("routes by provider_inference_match when request model implies anthropic provider", async () => {
+  it("prefers the active session over provider inference when both are available", async () => {
+    const upstreamServer = createServer();
+    const upstreamWss = new WebSocketServer({ server: upstreamServer });
+
+    await once(upstreamServer.listen(0, "127.0.0.1"), "listening");
+    const addr = upstreamServer.address();
+    assert.ok(addr && typeof addr === "object");
+    const upstreamUrl = `ws://127.0.0.1:${addr.port}`;
+
+    upstreamWss.on("connection", (ws) => {
+      ws.on("message", () => {
+        ws.send(JSON.stringify({
+          type: "response.completed",
+          response: {
+            id: "resp_active",
+            model: "gpt-5.4",
+            status: "completed",
+            output: [{ type: "message", content: [{ type: "output_text", text: "from active session" }] }],
+            usage: { input_tokens: 1, output_tokens: 1 },
+          },
+        }));
+      });
+    });
+
+    const proxy = createProxyServer({
+      openAIWsFactory: (_url, options) => new WebSocket(upstreamUrl, options),
+      fetchImpl: async () => new Response(JSON.stringify({
+        id: "msg_active", type: "message", role: "assistant",
+        model: "claude-sonnet-4-5", content: [], usage: { input_tokens: 1, output_tokens: 1 },
+      }), { status: 200, headers: { "content-type": "application/json" } }),
+    });
+
+    try {
+      await withCustomServer(proxy, async (baseUrl) => {
+        await request(baseUrl, "/admin/sessions", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ name: "codex-1", provider: "openai", token: "sk-openai-test", model_override: "gpt-5.4" }),
+        });
+
+        await request(baseUrl, "/admin/sessions", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ name: "claude", provider: "anthropic", token: "sk-ant-test" }),
+        });
+
+        const res = await request(baseUrl, "/v1/messages", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ model: "claude-sonnet-4-5", stream: false, messages: [{ role: "user", content: "hi" }] }),
+        });
+
+        assert.equal(res.status, 200);
+        assert.equal(res.headers.get("x-llm-session-used"), "codex-1");
+        assert.equal(res.headers.get("x-llm-routing-reason"), "active_session_fallback");
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) => upstreamWss.close((err) => (err ? reject(err) : resolve())));
+      await new Promise<void>((resolve, reject) => upstreamServer.close((err) => (err ? reject(err) : resolve())));
+    }
+  });
+
+  it("routes by provider_inference_match when request model implies anthropic provider and no active session exists", async () => {
     const proxy = createProxyServer({
       fetchImpl: async () => new Response(JSON.stringify({
         id: "msg_3", type: "message", role: "assistant",
@@ -454,7 +516,16 @@ describe("proxy HTTP routes", () => {
         body: JSON.stringify({ name: "my-anthropic", provider: "anthropic", token: "sk-ant-test" }),
       });
 
-      // Request with a claude model that has no exact match — should infer anthropic and pick my-anthropic
+      saveConfig({
+        active_session: null,
+        sessions: {
+          "my-anthropic": {
+            provider: "anthropic",
+            token: "sk-ant-test",
+          },
+        },
+      });
+
       const res = await request(baseUrl, "/v1/messages", {
         method: "POST",
         headers: { "content-type": "application/json" },

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -432,7 +432,7 @@ function resolveHttpRouting(req: IncomingMessage, body: any, chatSessionId: stri
   }
 
   const modelResolution = resolveModelRoutedSession(body.model);
-  if (modelResolution.resolvedSessionName) {
+  if (modelResolution.reason === "model_override_exact" || modelResolution.reason === "session_name_alias") {
     return {
       requestedSession: modelResolution.resolvedSessionName,
       requestedModel: modelResolution.requestedModel,
@@ -454,12 +454,32 @@ function resolveHttpRouting(req: IncomingMessage, body: any, chatSessionId: stri
   }
 
   const active = getActiveSession();
+  if (active) {
+    return {
+      requestedSession: active.name,
+      requestedModel: modelResolution.requestedModel,
+      resolvedSessionName: active.name,
+      inferredProvider: modelResolution.inferredProvider,
+      reason: "active_session_fallback",
+    };
+  }
+
+  if (modelResolution.resolvedSessionName) {
+    return {
+      requestedSession: modelResolution.resolvedSessionName,
+      requestedModel: modelResolution.requestedModel,
+      resolvedSessionName: modelResolution.resolvedSessionName,
+      inferredProvider: modelResolution.inferredProvider,
+      reason: modelResolution.reason,
+    };
+  }
+
   return {
-    requestedSession: active?.name || null,
+    requestedSession: null,
     requestedModel: modelResolution.requestedModel,
-    resolvedSessionName: active?.name || null,
+    resolvedSessionName: null,
     inferredProvider: modelResolution.inferredProvider,
-    reason: active ? "active_session_fallback" : null,
+    reason: null,
   };
 }
 


### PR DESCRIPTION
## Summary
- move active-session fallback ahead of provider_inference_match in HTTP routing
- keep exact model_override and session-name routing ahead of active-session fallback
- add regression coverage for active OpenAI sessions receiving claude-* requests
- document the updated phase-1 routing priority in lane-design

## Problem
Fixes #41.

Claude Code always sends a claude-* request model, even when the user has explicitly switched llm-switcher to an OpenAI session. The old routing order let provider inference grab those requests before the active session fallback ran, so the user-selected session was ignored.

## Testing
- node --import tsx --test src/proxy.test.ts