### PR TITLE
Fix stale routing reason assertion after issue 41

### DIFF
--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -144,7 +144,7 @@ describe("proxy HTTP routes", () => {
 
       assert.equal(res.status, 200);
       assert.equal(res.headers.get("x-llm-session-used"), "claude-work");
-      assert.equal(res.headers.get("x-llm-routing-reason"), "provider_inference_match");
+      assert.equal(res.headers.get("x-llm-routing-reason"), "active_session_fallback");
       const body = JSON.parse(res.text);
       assert.equal(body.content[0].text, "hello");
       assert.equal(fetchCalls.length, 1);


### PR DESCRIPTION
## Summary
- update the anthropic override test to expect active_session_fallback after the issue #41 routing-priority change

## Problem
After #41 merged, the router correctly prefers the active session over provider inference. One existing test still expected the old provider_inference_match reason, so merged main failed the proxy test suite.

## Testing
- node --import tsx --test src/proxy.test.ts