### PR TITLE
Auto-refresh Anthropic OAuth token on 401

### DIFF
--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -858,3 +858,168 @@ describe("worktree path rewriting", () => {
     }
   });
 });
+
+describe("Anthropic OAuth token auto-refresh on 401", () => {
+  it("re-sniffs token and retries when upstream returns 401", async () => {
+    const expiredToken = "sk-ant-oat01-expired";
+    const freshToken = "sk-ant-oat01-fresh";
+    let sniffCalled = false;
+    let fetchCallCount = 0;
+
+    const proxy = createProxyServer({
+      fetchImpl: async (_url, init) => {
+        fetchCallCount++;
+        const authHeader = (init?.headers as Record<string, string>)?.authorization ?? "";
+        if (authHeader.includes(expiredToken)) {
+          return new Response(JSON.stringify({ error: { type: "authentication_error", message: "invalid token" } }), {
+            status: 401,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        return new Response(JSON.stringify({ id: "msg_ok", type: "message", role: "assistant", content: [], model: "claude-opus-4-5", stop_reason: "end_turn", usage: { input_tokens: 10, output_tokens: 5 } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+      sniffOAuthTokenImpl: async (_timeout) => {
+        sniffCalled = true;
+        return freshToken;
+      },
+    });
+
+    await withCustomServer(proxy, async (baseUrl) => {
+      await request(baseUrl, "/admin/sessions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "ant-oauth", provider: "anthropic", token: expiredToken }),
+      });
+
+      const res = await request(baseUrl, "/v1/messages", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "claude-opus-4-5", max_tokens: 10, messages: [{ role: "user", content: "hi" }] }),
+      });
+
+      assert.equal(res.status, 200);
+      assert.ok(sniffCalled, "sniffOAuthToken should have been called");
+      assert.equal(fetchCallCount, 2, "should have made exactly 2 fetch calls (401 + retry)");
+      const body = JSON.parse(res.text);
+      assert.equal(body.id, "msg_ok");
+    });
+  });
+
+  it("returns 502 when re-sniff fails", async () => {
+    const proxy = createProxyServer({
+      fetchImpl: async () => {
+        return new Response(JSON.stringify({ error: { type: "authentication_error", message: "invalid token" } }), {
+          status: 401,
+          headers: { "content-type": "application/json" },
+        });
+      },
+      sniffOAuthTokenImpl: async (_timeout) => {
+        throw new Error("claude CLI not found");
+      },
+    });
+
+    await withCustomServer(proxy, async (baseUrl) => {
+      await request(baseUrl, "/admin/sessions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "ant-oauth-fail", provider: "anthropic", token: "sk-ant-oat01-broken" }),
+      });
+
+      const res = await request(baseUrl, "/v1/messages", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "claude-opus-4-5", max_tokens: 10, messages: [{ role: "user", content: "hi" }] }),
+      });
+
+      assert.equal(res.status, 502);
+      const body = JSON.parse(res.text);
+      assert.equal(body.error.type, "oauth_token_refresh_failed");
+    });
+  });
+
+  it("does not re-sniff for non-OAuth API key 401", async () => {
+    let sniffCalled = false;
+
+    const proxy = createProxyServer({
+      fetchImpl: async () => {
+        return new Response(JSON.stringify({ error: { type: "authentication_error", message: "invalid api key" } }), {
+          status: 401,
+          headers: { "content-type": "application/json" },
+        });
+      },
+      sniffOAuthTokenImpl: async (_timeout) => {
+        sniffCalled = true;
+        return "should-not-be-called";
+      },
+    });
+
+    await withCustomServer(proxy, async (baseUrl) => {
+      await request(baseUrl, "/admin/sessions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "ant-apikey", provider: "anthropic", token: "sk-ant-api03-not-oauth" }),
+      });
+
+      const res = await request(baseUrl, "/v1/messages", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "claude-opus-4-5", max_tokens: 10, messages: [{ role: "user", content: "hi" }] }),
+      });
+
+      assert.equal(res.status, 401, "non-OAuth 401 should be passed through");
+      assert.ok(!sniffCalled, "sniffOAuthToken should NOT be called for non-OAuth tokens");
+    });
+  });
+
+  it("deduplicates concurrent re-sniff calls with shared mutex", async () => {
+    const expiredToken = "sk-ant-oat01-old-token-xyz";
+    const freshToken = "sk-ant-oat01-new-token-abc";
+    let sniffCallCount = 0;
+
+    const proxy = createProxyServer({
+      fetchImpl: async (_url, init) => {
+        const authHeader = (init?.headers as Record<string, string>)?.authorization ?? "";
+        if (authHeader.includes(expiredToken)) {
+          return new Response(JSON.stringify({ error: { type: "authentication_error" } }), {
+            status: 401,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        return new Response(JSON.stringify({ id: "msg_concurrent", type: "message", role: "assistant", content: [], model: "claude-opus-4-5", stop_reason: "end_turn", usage: { input_tokens: 1, output_tokens: 1 } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+      sniffOAuthTokenImpl: async (_timeout) => {
+        sniffCallCount++;
+        await new Promise((r) => setTimeout(r, 20));
+        return freshToken;
+      },
+    });
+
+    await withCustomServer(proxy, async (baseUrl) => {
+      await request(baseUrl, "/admin/sessions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "ant-concurrent", provider: "anthropic", token: expiredToken }),
+      });
+
+      const requestBody = JSON.stringify({ model: "claude-opus-4-5", max_tokens: 10, messages: [{ role: "user", content: "hi" }] });
+      const headers = { "content-type": "application/json" };
+
+      const [r1, r2, r3] = await Promise.all([
+        request(baseUrl, "/v1/messages", { method: "POST", headers, body: requestBody }),
+        request(baseUrl, "/v1/messages", { method: "POST", headers, body: requestBody }),
+        request(baseUrl, "/v1/messages", { method: "POST", headers, body: requestBody }),
+      ]);
+
+      assert.equal(r1.status, 200);
+      assert.equal(r2.status, 200);
+      assert.equal(r3.status, 200);
+      assert.equal(sniffCallCount, 1, "sniffOAuthToken should only be called once despite concurrent 401s");
+    });
+  });
+});

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,6 +3,7 @@ import { WebSocketServer, WebSocket as WsWebSocket } from "ws";
 import { getActiveSession, listSessions, addSession, removeSession, setActive, updateSessionToken } from "./config.js";
 import type { Session } from "./config.js";
 import { buildCodexHeaders, refreshCodexToken, updateCodexAuthFile, loadCodexAuth } from "./codex.js";
+import { sniffOAuthToken } from "./login.js";
 import { inferProviderFromModel, pickDeterministicSessionName } from "./models.js";
 import { translateRequest, translateResponse, createWsEventProcessor } from "./translate.js";
 
@@ -14,6 +15,7 @@ interface ProxyDeps {
   openAIWsFactory?: WsFactory;
   codexBridgeWsFactory?: WsFactory;
   codexBridgeUrl?: string;
+  sniffOAuthTokenImpl?: (timeout?: number) => Promise<string | null>;
 }
 
 type RoutingReason =
@@ -140,6 +142,7 @@ interface SessionProbeStatus {
 const sessionObservability: Record<string, SessionObservability> = {};
 const sessionProbeStatus: Record<string, SessionProbeStatus> = {};
 const pendingTokenRefresh = new Map<string, Promise<import("./codex.js").CodexTokenRefreshResult>>();
+const pendingAnthropicRefresh = new Map<string, Promise<string | null>>();
 
 interface CachedWorktreeMapping {
   original: string;
@@ -198,6 +201,7 @@ export function resetRuntimeObservability(): void {
   for (const key of Object.keys(sessionObservability)) delete sessionObservability[key];
   for (const key of Object.keys(sessionProbeStatus)) delete sessionProbeStatus[key];
   pendingTokenRefresh.clear();
+  pendingAnthropicRefresh.clear();
   worktreeMappings.clear();
 }
 
@@ -566,18 +570,64 @@ async function handleProxy(
   body = injectBillingHeader({ ...body }, token);
 
   const upstreamUrl = getUpstreamUrl(baseUrl);
-  const upstreamHeaders = buildUpstreamHeaders(token, incomingHeaders);
   const isStream = body.stream === true;
+  const effectiveModel = typeof body.model === "string" ? body.model : session.model_override || null;
 
-  try {
-    const effectiveModel = typeof body.model === "string" ? body.model : session.model_override || null;
-    const upstreamRes = await deps.fetchImpl(upstreamUrl, {
-      method: "POST",
-      headers: upstreamHeaders,
-      body: JSON.stringify(body),
-    });
+  async function doAnthropicFetch(currentToken: string, canRetry: boolean): Promise<void> {
+    const upstreamHeaders = buildUpstreamHeaders(currentToken, incomingHeaders);
+    let upstreamRes: Response;
+    try {
+      upstreamRes = await deps.fetchImpl(upstreamUrl, {
+        method: "POST",
+        headers: upstreamHeaders,
+        body: JSON.stringify(body),
+      });
+    } catch (err) {
+      recordSessionError(session, {
+        requestedModel,
+        effectiveModel,
+        ...routingData,
+        type: "upstream_connection_error",
+        message: err instanceof Error ? err.message : String(err),
+      });
+      res.writeHead(502, { "content-type": "application/json", ...routingHeaders });
+      res.end(JSON.stringify({ error: { type: "upstream_connection_error", message: err instanceof Error ? err.message : String(err) } }));
+      return;
+    }
 
     updateRateLimits(session.name, upstreamRes.headers);
+
+    // Auto-refresh OAuth token on 401 and retry once
+    if (upstreamRes.status === 401 && isOAuthToken(currentToken) && canRetry) {
+      console.error(`[Anthropic] Token expired (401), attempting re-sniff for session '${session.name}'`);
+      try {
+        let refreshPromise = pendingAnthropicRefresh.get(session.name);
+        if (!refreshPromise) {
+          refreshPromise = deps.sniffOAuthTokenImpl(15000).finally(() => {
+            pendingAnthropicRefresh.delete(session.name);
+          });
+          pendingAnthropicRefresh.set(session.name, refreshPromise);
+        }
+        const newToken = await refreshPromise;
+        if (!newToken) throw new Error("sniffOAuthToken returned null — claude CLI unavailable or not logged in");
+        updateSessionToken(session.name, newToken);
+        session.token = newToken;
+        // Re-inject billing header with the new token before retrying
+        body = injectBillingHeader({ ...body }, newToken);
+        console.error(`[Anthropic] Token refreshed, retrying`);
+        return doAnthropicFetch(newToken, false);
+      } catch (refreshErr) {
+        console.error(`[Anthropic] Token refresh failed:`, (refreshErr as Error).message);
+        res.writeHead(502, { "content-type": "application/json", ...routingHeaders });
+        res.end(JSON.stringify({
+          error: {
+            type: "oauth_token_refresh_failed",
+            message: `Auto-refresh failed: ${(refreshErr as Error).message}. Run 'llm-switcher login' to manually refresh.`,
+          },
+        }));
+        return;
+      }
+    }
 
     if (isStream && upstreamRes.ok && upstreamRes.body) {
       recordSessionSuccess(session, {
@@ -637,19 +687,9 @@ async function handleProxy(
         });
       }
     }
-  } catch (err) {
-    const effectiveModel = typeof body.model === "string" ? body.model : session.model_override || null;
-    recordSessionError(session, {
-      requestedModel,
-      effectiveModel,
-      ...routingData,
-      type: "upstream_connection_error",
-      message: err instanceof Error ? err.message : String(err),
-    });
-    res.writeHead(502, { "content-type": "application/json", ...routingHeaders });
-    res.end(JSON.stringify({ error: { type: "upstream_connection_error", message: err instanceof Error ? err.message : String(err) } }));
-    return;
   }
+
+  return doAnthropicFetch(token, true);
 }
 
 async function handleOpenAIProxy(
@@ -1271,6 +1311,7 @@ export function createProxyServer(customDeps: ProxyDeps = {}) {
     openAIWsFactory: customDeps.openAIWsFactory || ((url, options) => new WsWebSocket(url, options)),
     codexBridgeWsFactory: customDeps.codexBridgeWsFactory || ((url, options) => new WsWebSocket(url, options)),
     codexBridgeUrl: customDeps.codexBridgeUrl || "wss://chatgpt.com/backend-api/codex/responses",
+    sniffOAuthTokenImpl: customDeps.sniffOAuthTokenImpl || sniffOAuthToken,
   };
 
   const server = createServer(async (req, res) => {


### PR DESCRIPTION
## Summary

- When an Anthropic OAuth session token (`sk-ant-oat01-*`) expires, the proxy now transparently re-sniffs a fresh token via `sniffOAuthToken()` and retries the original request once — instead of passing the 401 back to Claude Code
- Mirrors the Codex auto-refresh pattern from #38, using a `pendingAnthropicRefresh` mutex to deduplicate concurrent 401s (only one `sniffOAuthToken()` subprocess spawned even under load)
- Non-OAuth API keys: 401 is passed through unchanged
- Re-sniff failure: returns 502 with `oauth_token_refresh_failed` + message prompting `llm-switcher login`
- `sniffOAuthTokenImpl` added to `ProxyDeps` for injection in tests (avoids spawning real subprocess)

## Test plan

- [x] 401 → re-sniff → retry succeeds (status 200, 2 fetch calls)
- [x] Re-sniff failure → 502 with `oauth_token_refresh_failed`
- [x] Non-OAuth token 401 → passed through, no re-sniff triggered
- [x] Concurrent 401s → only 1 `sniffOAuthToken()` call (mutex dedup)
- [x] All 121 existing tests still pass

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)