### PR TITLE
Stabilize runtime reliability: config, lifecycle, failure semantics, observability

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,7 +44,7 @@ program
       process.exit(1);
     }
     console.log(`Token captured: ${token.slice(0, 20)}...${token.slice(-10)}`);
-    addSession(name, "anthropic", token);
+    await addSession(name, "anthropic", token);
     console.log(`\u2713 Session '${name}' ready with fresh OAuth token`);
 
     if (process.env.ANTHROPIC_API_KEY) {
@@ -72,7 +72,7 @@ program
     console.log(`Account ID: ${accountId}`);
 
     const refreshToken = auth.tokens.refresh_token;
-    addSession(name, "openai", token, undefined, undefined, accountId, refreshToken);
+    await addSession(name, "openai", token, undefined, undefined, accountId, refreshToken);
     console.log(`\u2713 Session '${name}' ready with Codex OAuth token${refreshToken ? " (auto-refresh enabled)" : ""}`);
   });
 
@@ -93,8 +93,8 @@ program
     tryHttp("POST", "/admin/sessions", {
       name, provider: opts.provider, token: opts.token,
       base_url: opts.baseUrl, model_override: opts.model,
-    }).then((ok) => {
-      if (!ok) addSession(name, opts.provider, opts.token, opts.baseUrl, opts.model);
+    }).then(async (ok) => {
+      if (!ok) await addSession(name, opts.provider, opts.token, opts.baseUrl, opts.model);
       console.log(`\u2713 Added session '${name}' (${opts.provider})`);
     });
   });
@@ -105,7 +105,7 @@ program
   .description("Remove an LLM session")
   .action(async (name) => {
     const ok = await tryHttp("DELETE", `/admin/sessions/${name}`);
-    if (!ok) removeSession(name);
+    if (!ok) await removeSession(name);
     console.log(`\u2713 Removed session '${name}'`);
   });
 
@@ -239,9 +239,9 @@ program
 program
   .command("set-model <name> <model>")
   .description("Set the configured model for a session")
-  .action((name, model) => {
+  .action(async (name, model) => {
     try {
-      setSessionModel(name, model);
+      await setSessionModel(name, model);
     } catch (e: any) {
       console.error(`Error: ${e.message}`);
       process.exit(1);
@@ -256,7 +256,7 @@ program
   .action(async (name) => {
     const ok = await tryHttp("POST", `/admin/switch/${name}`);
     if (!ok) {
-      try { setActive(name); } catch (e: any) {
+      try { await setActive(name); } catch (e: any) {
         console.error(`Error: ${e.message}`);
         process.exit(1);
       }

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -13,6 +13,7 @@ import {
   saveConfig,
   setActive,
   setSessionModel,
+  updateSessionToken,
 } from "./config.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -48,8 +49,8 @@ describe("config persistence", () => {
     assert.equal(mode, 0o600);
   });
 
-  it("adds the first session as active and persists defaults", () => {
-    addSession("claude-work", "anthropic", "sk-ant-test");
+  it("adds the first session as active and persists defaults", async () => {
+    await addSession("claude-work", "anthropic", "sk-ant-test");
 
     const active = getActiveSession();
     assert.ok(active);
@@ -58,9 +59,9 @@ describe("config persistence", () => {
     assert.equal(active.base_url, "https://api.anthropic.com");
   });
 
-  it("does not replace the active session when adding another one", () => {
-    addSession("claude-work", "anthropic", "sk-ant-test");
-    addSession("gpt-work", "openai", "sk-openai-test", undefined, "gpt-5.4", "acct_123");
+  it("does not replace the active session when adding another one", async () => {
+    await addSession("claude-work", "anthropic", "sk-ant-test");
+    await addSession("gpt-work", "openai", "sk-openai-test", undefined, "gpt-5.4", "acct_123");
 
     const active = getActiveSession();
     assert.ok(active);
@@ -72,20 +73,20 @@ describe("config persistence", () => {
     assert.equal(listed.sessions["gpt-work"].base_url, "https://api.openai.com");
   });
 
-  it("switches the active session", () => {
-    addSession("claude-work", "anthropic", "sk-ant-test");
-    addSession("gpt-work", "openai", "sk-openai-test");
+  it("switches the active session", async () => {
+    await addSession("claude-work", "anthropic", "sk-ant-test");
+    await addSession("gpt-work", "openai", "sk-openai-test");
 
-    setActive("gpt-work");
+    await setActive("gpt-work");
 
     const active = getActiveSession();
     assert.ok(active);
     assert.equal(active.name, "gpt-work");
   });
 
-  it("returns a named session without changing the active session", () => {
-    addSession("claude-work", "anthropic", "sk-ant-test");
-    addSession("gpt-work", "openai", "sk-openai-test", undefined, "gpt-5.4");
+  it("returns a named session without changing the active session", async () => {
+    await addSession("claude-work", "anthropic", "sk-ant-test");
+    await addSession("gpt-work", "openai", "sk-openai-test", undefined, "gpt-5.4");
 
     const session = getSession("gpt-work");
     assert.ok(session);
@@ -94,37 +95,103 @@ describe("config persistence", () => {
     assert.equal(getActiveSession()?.name, "claude-work");
   });
 
-  it("returns null for a missing named session", () => {
-    addSession("claude-work", "anthropic", "sk-ant-test");
+  it("returns null for a missing named session", async () => {
+    await addSession("claude-work", "anthropic", "sk-ant-test");
     assert.equal(getSession("missing"), null);
   });
 
-  it("updates the configured model for a named session", () => {
-    addSession("claude-work", "anthropic", "sk-ant-test");
-    addSession("gpt-work", "openai", "sk-openai-test");
+  it("updates the configured model for a named session", async () => {
+    await addSession("claude-work", "anthropic", "sk-ant-test");
+    await addSession("gpt-work", "openai", "sk-openai-test");
 
-    setSessionModel("claude-work", "claude-sonnet-4-5");
-    setSessionModel("gpt-work", "gpt-5.4");
+    await setSessionModel("claude-work", "claude-sonnet-4-5");
+    await setSessionModel("gpt-work", "gpt-5.4");
 
     assert.equal(getSession("claude-work")?.model_override, "claude-sonnet-4-5");
     assert.equal(getSession("gpt-work")?.model_override, "gpt-5.4");
   });
 
-  it("throws when setting a model for a missing session", () => {
-    addSession("claude-work", "anthropic", "sk-ant-test");
-    assert.throws(() => setSessionModel("missing", "gpt-5.4"), /not found/);
+  it("throws when setting a model for a missing session", async () => {
+    await addSession("claude-work", "anthropic", "sk-ant-test");
+    await assert.rejects(() => setSessionModel("missing", "gpt-5.4"), /not found/);
   });
 
-  it("throws when switching to a missing session", () => {
-    addSession("claude-work", "anthropic", "sk-ant-test");
-    assert.throws(() => setActive("missing"), /not found/);
+  it("throws when switching to a missing session", async () => {
+    await addSession("claude-work", "anthropic", "sk-ant-test");
+    await assert.rejects(() => setActive("missing"), /not found/);
   });
 
-  it("clears active_session when removing the active session", () => {
-    addSession("claude-work", "anthropic", "sk-ant-test");
-    removeSession("claude-work");
+  it("clears active_session when removing the active session", async () => {
+    await addSession("claude-work", "anthropic", "sk-ant-test");
+    await removeSession("claude-work");
 
     assert.equal(getActiveSession(), null);
     assert.equal(listSessions().active_session, null);
+  });
+});
+
+describe("config write serialization", () => {
+  it("concurrent addSession calls do not lose data", async () => {
+    // Fire 10 addSession calls concurrently — all must survive in config.
+    await Promise.all(
+      Array.from({ length: 10 }, (_, i) =>
+        addSession(`session-${i}`, "anthropic", `sk-ant-token-${i}`)
+      )
+    );
+
+    const { sessions } = listSessions();
+    for (let i = 0; i < 10; i++) {
+      assert.ok(sessions[`session-${i}`], `session-${i} should be present`);
+      assert.equal(sessions[`session-${i}`].token, `sk-ant-token-${i}`);
+    }
+    assert.equal(Object.keys(sessions).length, 10);
+  });
+
+  it("concurrent updateSessionToken calls do not corrupt each other", async () => {
+    await addSession("shared", "anthropic", "sk-ant-initial");
+
+    // 20 concurrent token updates — last writer wins, but no corruption
+    const tokens = Array.from({ length: 20 }, (_, i) => `sk-ant-token-v${i}`);
+    await Promise.all(tokens.map((t) => updateSessionToken("shared", t)));
+
+    const session = getSession("shared");
+    assert.ok(session, "session should still exist after concurrent updates");
+    // Token must be one of the valid values written — not corrupted JSON
+    assert.ok(tokens.includes(session.token), `token '${session.token}' should be one of the written values`);
+  });
+
+  it("interleaved addSession and setActive do not corrupt active_session", async () => {
+    await addSession("alpha", "anthropic", "sk-ant-alpha");
+    await addSession("beta", "openai", "sk-openai-beta");
+
+    // Concurrently: keep switching active while also adding a new session
+    await Promise.all([
+      setActive("alpha"),
+      setActive("beta"),
+      addSession("gamma", "anthropic", "sk-ant-gamma"),
+      setActive("alpha"),
+    ]);
+
+    const { active_session, sessions } = listSessions();
+    assert.ok(["alpha", "beta"].includes(active_session!), "active session should be one of the valid names");
+    assert.ok(sessions["gamma"], "gamma session should have been added");
+  });
+
+  it("config file is never left in a truncated state on disk", async () => {
+    // The atomic temp-rename strategy means the file is always a complete JSON.
+    await addSession("robust", "anthropic", "sk-ant-robust");
+
+    // Run concurrent writes; after each completes, the file must be valid JSON.
+    const checks: Promise<void>[] = [];
+    for (let i = 0; i < 20; i++) {
+      checks.push(
+        addSession(`concurrent-${i}`, "openai", `sk-openai-${i}`).then(() => {
+          const raw = readFileSync(CONFIG_PATH, "utf-8");
+          // Must be valid JSON — never a partial write
+          assert.doesNotThrow(() => JSON.parse(raw), `config.json should be valid JSON after write ${i}`);
+        })
+      );
+    }
+    await Promise.all(checks);
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, chmodSync, existsSync } from "node:fs";
+import { readFileSync, writeFileSync, chmodSync, existsSync, renameSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -19,61 +19,45 @@ export interface Config {
   sessions: Record<string, Session>;
 }
 
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Write config atomically: temp file → rename, so a crash mid-write never
+ *  leaves a truncated config.json.  Also sets mode 0600. */
+function atomicSave(config: Config): void {
+  const tmp = `${CONFIG_PATH}.tmp`;
+  writeFileSync(tmp, JSON.stringify(config, null, 2));
+  chmodSync(tmp, 0o600);
+  renameSync(tmp, CONFIG_PATH);
+}
+
+/** Process-level write serialization: all mutations are queued on this
+ *  promise chain so concurrent requests never interleave load → save pairs. */
+let writeLock: Promise<void> = Promise.resolve();
+
+function withLock<T>(fn: () => T): Promise<T> {
+  const result = writeLock.then(() => fn());
+  // Keep the chain alive even if fn() throws, so later callers aren't stuck.
+  writeLock = (result as Promise<unknown>).then(
+    () => {},
+    () => {},
+  );
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Public read API  (no lock needed — reads are always consistent because
+// writes are atomic rename operations)
+// ---------------------------------------------------------------------------
+
 export function loadConfig(): Config {
   if (!existsSync(CONFIG_PATH)) {
     const def: Config = { active_session: null, sessions: {} };
-    saveConfig(def);
+    atomicSave(def);
     return def;
   }
   return JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
-}
-
-export function saveConfig(config: Config): void {
-  writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2));
-  chmodSync(CONFIG_PATH, 0o600);
-}
-
-export function addSession(
-  name: string,
-  provider: "anthropic" | "openai",
-  token: string,
-  baseUrl?: string,
-  modelOverride?: string,
-  accountId?: string,
-  refreshToken?: string,
-): void {
-  const config = loadConfig();
-  config.sessions[name] = {
-    provider,
-    token,
-    base_url: baseUrl ?? (provider === "anthropic" ? "https://api.anthropic.com" : "https://api.openai.com"),
-    ...(modelOverride ? { model_override: modelOverride } : {}),
-    ...(accountId ? { account_id: accountId } : {}),
-    ...(refreshToken ? { refresh_token: refreshToken } : {}),
-  };
-  if (!config.active_session) config.active_session = name;
-  saveConfig(config);
-}
-
-export function updateSessionToken(name: string, token: string): void {
-  const config = loadConfig();
-  if (!config.sessions[name]) throw new Error(`Session '${name}' not found`);
-  config.sessions[name].token = token;
-  saveConfig(config);
-}
-
-export function removeSession(name: string): void {
-  const config = loadConfig();
-  delete config.sessions[name];
-  if (config.active_session === name) config.active_session = null;
-  saveConfig(config);
-}
-
-export function setActive(name: string): void {
-  const config = loadConfig();
-  if (!(name in config.sessions)) throw new Error(`Session '${name}' not found`);
-  config.active_session = name;
-  saveConfig(config);
 }
 
 export function getActiveSession(): (Session & { name: string }) | null {
@@ -91,15 +75,81 @@ export function getSession(name: string): (Session & { name: string }) | null {
   return { name, ...session };
 }
 
-export function setSessionModel(name: string, model: string): void {
-  const config = loadConfig();
-  const session = config.sessions[name];
-  if (!session) throw new Error(`Session '${name}' not found`);
-  session.model_override = model;
-  saveConfig(config);
-}
-
 export function listSessions(): { sessions: Record<string, Session>; active_session: string | null } {
   const config = loadConfig();
   return { sessions: config.sessions, active_session: config.active_session };
+}
+
+// ---------------------------------------------------------------------------
+// saveConfig — kept for test fixtures and one-shot CLI bootstrap.
+// Prefer the async mutation functions below for all runtime writes.
+// ---------------------------------------------------------------------------
+
+export function saveConfig(config: Config): void {
+  atomicSave(config);
+}
+
+// ---------------------------------------------------------------------------
+// Public write API  (serialized via writeLock)
+// ---------------------------------------------------------------------------
+
+export function addSession(
+  name: string,
+  provider: "anthropic" | "openai",
+  token: string,
+  baseUrl?: string,
+  modelOverride?: string,
+  accountId?: string,
+  refreshToken?: string,
+): Promise<void> {
+  return withLock(() => {
+    const config = loadConfig();
+    config.sessions[name] = {
+      provider,
+      token,
+      base_url: baseUrl ?? (provider === "anthropic" ? "https://api.anthropic.com" : "https://api.openai.com"),
+      ...(modelOverride ? { model_override: modelOverride } : {}),
+      ...(accountId ? { account_id: accountId } : {}),
+      ...(refreshToken ? { refresh_token: refreshToken } : {}),
+    };
+    if (!config.active_session) config.active_session = name;
+    atomicSave(config);
+  });
+}
+
+export function updateSessionToken(name: string, token: string): Promise<void> {
+  return withLock(() => {
+    const config = loadConfig();
+    if (!config.sessions[name]) throw new Error(`Session '${name}' not found`);
+    config.sessions[name].token = token;
+    atomicSave(config);
+  });
+}
+
+export function removeSession(name: string): Promise<void> {
+  return withLock(() => {
+    const config = loadConfig();
+    delete config.sessions[name];
+    if (config.active_session === name) config.active_session = null;
+    atomicSave(config);
+  });
+}
+
+export function setActive(name: string): Promise<void> {
+  return withLock(() => {
+    const config = loadConfig();
+    if (!(name in config.sessions)) throw new Error(`Session '${name}' not found`);
+    config.active_session = name;
+    atomicSave(config);
+  });
+}
+
+export function setSessionModel(name: string, model: string): Promise<void> {
+  return withLock(() => {
+    const config = loadConfig();
+    const session = config.sessions[name];
+    if (!session) throw new Error(`Session '${name}' not found`);
+    session.model_override = model;
+    atomicSave(config);
+  });
 }

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -893,6 +893,92 @@ describe("worktree path rewriting", () => {
   });
 });
 
+describe("admin session bindings", () => {
+  it("GET /admin/sessions includes chat_session_bindings", async () => {
+    await withServer(async (baseUrl) => {
+      await request(baseUrl, "/admin/sessions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "s", provider: "anthropic", token: "sk-ant-test" }),
+      });
+
+      // Bind a chat session
+      await request(baseUrl, "/admin/chat-bind/chat-abc/s", { method: "POST" });
+
+      const res = await request(baseUrl, "/admin/sessions");
+      const body = JSON.parse(res.text);
+      assert.ok(body.chat_session_bindings, "should include chat_session_bindings");
+      assert.equal(body.chat_session_bindings["chat-abc"], "s");
+    });
+  });
+});
+
+describe("failure semantics — translation_error", () => {
+  it("returns 502 translation_error when OpenAI response has malformed tool call JSON", async () => {
+    const { once: onceEv, EventEmitter } = await import("node:events");
+
+    const upstreamServer = createServer();
+    const upstreamWss = new WebSocketServer({ server: upstreamServer });
+
+    await onceEv(upstreamServer.listen(0, "127.0.0.1"), "listening");
+    const addr = upstreamServer.address();
+    assert.ok(addr && typeof addr === "object");
+    const upstreamUrl = `ws://127.0.0.1:${addr.port}`;
+
+    upstreamWss.on("connection", (ws) => {
+      ws.on("message", () => {
+        ws.send(JSON.stringify({
+          type: "response.completed",
+          response: {
+            id: "resp_bad",
+            model: "gpt-5.4",
+            status: "completed",
+            output: [{
+              type: "function_call",
+              call_id: "call_x",
+              name: "Edit",
+              arguments: "NOT VALID JSON {{{{",
+            }],
+            usage: { input_tokens: 1, output_tokens: 1 },
+          },
+        }));
+      });
+    });
+
+    const proxy = createProxyServer({
+      openAIWsFactory: (_url, options) => new WebSocket(upstreamUrl, options),
+    });
+
+    try {
+      await withCustomServer(proxy, async (baseUrl) => {
+        await request(baseUrl, "/admin/sessions", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ name: "gpt-bad", provider: "openai", token: "sk-test", model_override: "gpt-5.4" }),
+        });
+
+        const res = await request(baseUrl, "/v1/messages", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            stream: false,
+            model: "gpt-5.4",
+            messages: [{ role: "user", content: "hi" }],
+          }),
+        });
+
+        assert.equal(res.status, 502);
+        const body = JSON.parse(res.text);
+        assert.equal(body.error.type, "translation_error");
+        assert.match(body.error.message, /Invalid JSON in tool call arguments/);
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) => upstreamWss.close((err) => (err ? reject(err) : resolve())));
+      await new Promise<void>((resolve, reject) => upstreamServer.close((err) => (err ? reject(err) : resolve())));
+    }
+  });
+});
+
 describe("Anthropic OAuth token auto-refresh on 401", () => {
   it("re-sniffs token and retries when upstream returns 401", async () => {
     const expiredToken = "sk-ant-oat01-expired";

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -153,6 +153,40 @@ describe("proxy HTTP routes", () => {
     });
   });
 
+  it("includes x-llm-request-id in every response", async () => {
+    const proxy = createProxyServer({
+      fetchImpl: async () => new Response(JSON.stringify({ id: "msg_1", type: "message", role: "assistant", content: [], model: "claude-opus-4-5", stop_reason: "end_turn", usage: { input_tokens: 1, output_tokens: 1 } }), {
+        status: 200, headers: { "content-type": "application/json" },
+      }),
+    });
+
+    await withCustomServer(proxy, async (baseUrl) => {
+      await request(baseUrl, "/admin/sessions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "s1", provider: "anthropic", token: "sk-ant-test" }),
+      });
+
+      const r1 = await request(baseUrl, "/v1/messages", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "claude-opus-4-5", max_tokens: 10, messages: [{ role: "user", content: "hi" }] }),
+      });
+      const r2 = await request(baseUrl, "/v1/messages", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "claude-opus-4-5", max_tokens: 10, messages: [{ role: "user", content: "hi" }] }),
+      });
+
+      const id1 = r1.headers.get("x-llm-request-id");
+      const id2 = r2.headers.get("x-llm-request-id");
+      assert.ok(id1, "x-llm-request-id should be present");
+      assert.ok(id2, "x-llm-request-id should be present");
+      assert.match(id1!, /^[0-9a-f-]{36}$/, "request-id should be a UUID");
+      assert.notEqual(id1, id2, "each request should get a unique id");
+    });
+  });
+
   it("uses the lean OAuth header set and billing block for anthropic OAuth sessions", async () => {
     const fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
     const proxy = createProxyServer({

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -610,7 +610,7 @@ async function handleProxy(
         }
         const newToken = await refreshPromise;
         if (!newToken) throw new Error("sniffOAuthToken returned null — claude CLI unavailable or not logged in");
-        updateSessionToken(session.name, newToken);
+        await updateSessionToken(session.name, newToken);
         session.token = newToken;
         // Re-inject billing header with the new token before retrying
         body = injectBillingHeader({ ...body }, newToken);
@@ -823,7 +823,7 @@ async function handleOpenAIProxy(
               pendingTokenRefresh.set(session.name, refreshPromise);
             }
             const result = await refreshPromise;
-            updateSessionToken(session.name, result.access_token);
+            await updateSessionToken(session.name, result.access_token);
             updateCodexAuthFile(result);
             session.token = result.access_token;
             if (result.refresh_token) session.refresh_token = result.refresh_token;
@@ -1128,7 +1128,7 @@ async function handleAdmin(
       res.end(JSON.stringify({ error: { type: "invalid_request", message: "name, provider, and token are required" } }));
       return;
     }
-    addSession(body.name, body.provider, body.token, body.base_url, body.model_override, body.account_id, body.refresh_token);
+    await addSession(body.name, body.provider, body.token, body.base_url, body.model_override, body.account_id, body.refresh_token);
     res.writeHead(201, { "content-type": "application/json" });
     res.end(JSON.stringify({ ok: true }));
     return;
@@ -1136,7 +1136,7 @@ async function handleAdmin(
 
   if (req.method === "DELETE" && path.startsWith("/admin/sessions/")) {
     const name = decodeURIComponent(path.slice("/admin/sessions/".length));
-    removeSession(name);
+    await removeSession(name);
     res.writeHead(204);
     res.end();
     return;
@@ -1145,7 +1145,7 @@ async function handleAdmin(
   if (req.method === "POST" && path.startsWith("/admin/switch/")) {
     const name = decodeURIComponent(path.slice("/admin/switch/".length));
     try {
-      setActive(name);
+      await setActive(name);
       res.end(JSON.stringify({ ok: true, active_session: name }));
     } catch (err) {
       res.writeHead(404, { "content-type": "application/json" });

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,4 +1,5 @@
 import { createServer, IncomingMessage, ServerResponse } from "node:http";
+import { randomUUID } from "node:crypto";
 import { WebSocketServer, WebSocket as WsWebSocket } from "ws";
 import { getActiveSession, listSessions, addSession, removeSession, setActive, updateSessionToken } from "./config.js";
 import type { Session } from "./config.js";
@@ -33,6 +34,46 @@ interface RoutingResolution {
   resolvedSessionName: string | null;
   inferredProvider: Session["provider"] | null;
   reason: RoutingReason | null;
+}
+
+/** Immutable per-request context built once after routing resolution.
+ *  Carries every piece of routing/tracing data so it doesn't have to be
+ *  threaded as separate parameters through every helper. */
+interface RequestContext {
+  /** UUID for end-to-end request tracing (returned as x-llm-request-id). */
+  readonly requestId: string;
+  readonly chatSessionId: string | null;
+  readonly sessionName: string;
+  readonly routingReason: RoutingReason | null;
+  readonly requestedModel: string | null;
+  readonly resolvedSession: string | null;
+  readonly inferredProvider: Session["provider"] | null;
+  readonly startedAt: number;
+}
+
+function buildRequestContext(
+  chatSessionId: string | null,
+  session: { name: string },
+  resolution: RoutingResolution,
+): RequestContext {
+  return {
+    requestId: randomUUID(),
+    chatSessionId,
+    sessionName: session.name,
+    routingReason: resolution.reason,
+    requestedModel: resolution.requestedModel,
+    resolvedSession: resolution.resolvedSessionName,
+    inferredProvider: resolution.inferredProvider,
+    startedAt: Date.now(),
+  };
+}
+
+function buildResponseHeaders(ctx: RequestContext): Record<string, string> {
+  return {
+    "x-llm-session-used": ctx.sessionName,
+    "x-llm-request-id": ctx.requestId,
+    ...(ctx.routingReason ? { "x-llm-routing-reason": ctx.routingReason } : {}),
+  };
 }
 
 function sessionUsedHeader(sessionName: string, reason?: RoutingReason | null): Record<string, string> {
@@ -548,14 +589,15 @@ async function handleProxy(
     return;
   }
 
-  const routingHeaders = sessionUsedHeader(session.name, resolution.reason);
+  const ctx = buildRequestContext(chatSessionId, session, resolution);
+  const routingHeaders = buildResponseHeaders(ctx);
   const routingData = getRoutingReasonData(resolution);
 
   if (session.provider === "openai") {
-    return handleOpenAIProxy(res, body, session, deps, routingHeaders, routingData, chatSessionId);
+    return handleOpenAIProxy(res, body, session, deps, ctx, routingData);
   }
 
-  const requestedModel = typeof body.model === "string" ? body.model : null;
+  const requestedModel = ctx.requestedModel;
   const token = session.token;
   const baseUrl = session.base_url || "https://api.anthropic.com";
   const incomingHeaders: Record<string, string> = {};
@@ -697,10 +739,10 @@ async function handleOpenAIProxy(
   requestBody: any,
   session: { name: string; token: string; model_override?: string; account_id?: string; refresh_token?: string },
   deps: Required<ProxyDeps>,
-  responseHeaders: Record<string, string> = sessionUsedHeader(session.name),
+  ctx: RequestContext,
   routingData: { resolvedSession?: string | null; inferredProvider?: Session["provider"] | null; resolutionReason?: RoutingReason | null } = {},
-  chatSessionId: string | null = null,
 ): Promise<void> {
+  const responseHeaders = buildResponseHeaders(ctx);
   let translated;
   try {
     translated = translateRequest(requestBody, session);
@@ -710,7 +752,7 @@ async function handleOpenAIProxy(
     return;
   }
 
-  const worktreeMapping = getWorktreeMapping(chatSessionId, requestBody.system);
+  const worktreeMapping = getWorktreeMapping(ctx.chatSessionId, requestBody.system);
 
   const translatedBody = JSON.parse(translated.body);
   const isStream = requestBody.stream === true;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,7 +6,7 @@ import type { Session } from "./config.js";
 import { buildCodexHeaders, refreshCodexToken, updateCodexAuthFile, loadCodexAuth } from "./codex.js";
 import { sniffOAuthToken } from "./login.js";
 import { inferProviderFromModel, pickDeterministicSessionName } from "./models.js";
-import { translateRequest, translateResponse, createWsEventProcessor } from "./translate.js";
+import { translateRequest, translateResponse, createWsEventProcessor, TranslationError } from "./translate.js";
 
 type FetchImpl = typeof fetch;
 type WsFactory = (url: string, options?: { headers?: Record<string, string> }) => WsWebSocket;
@@ -161,6 +161,8 @@ interface SessionObservability {
   last_used_at: string | null;
   last_error: { type: string; message: string; status?: number } | null;
   last_usage: SessionUsageSnapshot | null;
+  last_request_id: string | null;
+  last_chat_session_id: string | null;
   totals: {
     input_tokens: number;
     output_tokens: number;
@@ -264,6 +266,8 @@ function getSessionObservability(session: { name: string; model_override?: strin
       last_used_at: null,
       last_error: null,
       last_usage: null,
+      last_request_id: null,
+      last_chat_session_id: null,
       totals: {
         input_tokens: 0,
         output_tokens: 0,
@@ -299,6 +303,7 @@ function recordSessionSuccess(
     inferredProvider?: Session["provider"] | null;
     resolutionReason?: RoutingReason | null;
     usage?: { input_tokens?: number; output_tokens?: number } | null;
+    ctx?: RequestContext;
   },
 ): void {
   const snapshot = getSessionObservability(session);
@@ -309,6 +314,10 @@ function recordSessionSuccess(
   snapshot.last_resolution_reason = data.resolutionReason ?? snapshot.last_resolution_reason;
   snapshot.last_used_at = new Date().toISOString();
   snapshot.last_error = null;
+  if (data.ctx) {
+    snapshot.last_request_id = data.ctx.requestId;
+    snapshot.last_chat_session_id = data.ctx.chatSessionId;
+  }
   snapshot.totals.requests += 1;
 
   if (data.usage) {
@@ -331,6 +340,7 @@ function recordSessionError(
     type: string;
     message: string;
     status?: number;
+    ctx?: RequestContext;
   },
 ): void {
   const snapshot = getSessionObservability(session);
@@ -340,6 +350,10 @@ function recordSessionError(
   snapshot.last_inferred_provider = data.inferredProvider ?? snapshot.last_inferred_provider;
   snapshot.last_resolution_reason = data.resolutionReason ?? snapshot.last_resolution_reason;
   snapshot.last_used_at = new Date().toISOString();
+  if (data.ctx) {
+    snapshot.last_request_id = data.ctx.requestId;
+    snapshot.last_chat_session_id = data.ctx.chatSessionId;
+  }
   snapshot.last_error = {
     type: data.type,
     message: data.message,
@@ -676,6 +690,7 @@ async function handleProxy(
         requestedModel,
         effectiveModel,
         ...routingData,
+        ctx,
       });
       res.writeHead(upstreamRes.status, {
         "content-type": "text/event-stream",
@@ -711,6 +726,7 @@ async function handleProxy(
           effectiveModel,
           ...routingData,
           usage: parsed?.usage || null,
+          ctx,
         });
       } else {
         let parsed: any = null;
@@ -726,6 +742,7 @@ async function handleProxy(
           type: parsed?.error?.type || "upstream_error",
           message: parsed?.error?.message || `Upstream error ${upstreamRes.status}`,
           status: upstreamRes.status,
+          ctx,
         });
       }
     }
@@ -834,13 +851,34 @@ async function handleOpenAIProxy(
           ws.close();
         }
       } else if (event.type === "response.completed") {
+        let anthropicRes: any;
+        let pathRewritten = false;
+        try {
+          ({ response: anthropicRes, pathRewritten } = translateResponse(event.response, worktreeMapping));
+        } catch (translateErr) {
+          const msg = translateErr instanceof TranslationError
+            ? translateErr.message
+            : `Unexpected translation error: ${(translateErr as Error).message}`;
+          console.error(`[OpenAI] ${msg}`);
+          recordSessionError(session, {
+            requestedModel,
+            effectiveModel,
+            ...routingData,
+            type: "translation_error",
+            message: msg,
+            ctx,
+          });
+          endResponse(502, { error: { type: "translation_error", message: msg } });
+          ws.close();
+          return;
+        }
         recordSessionSuccess(session, {
           requestedModel,
           effectiveModel,
           ...routingData,
           usage: event.response?.usage || null,
+          ctx,
         });
-        const { response: anthropicRes, pathRewritten } = translateResponse(event.response, worktreeMapping);
         endResponse(200, anthropicRes, pathRewritten ? { "x-llm-path-rewritten": "true" } : undefined);
         ws.close();
       }
@@ -1159,7 +1197,11 @@ async function handleAdmin(
         Object.entries(sessions).map(([name, session]) => [name, { ...getSessionAdminView(name, session), ...health[name] }]),
       );
     }
-    res.end(JSON.stringify({ sessions: annotatedSessions, active_session }));
+    res.end(JSON.stringify({
+      sessions: annotatedSessions,
+      active_session,
+      chat_session_bindings: { ...chatSessionMap },
+    }));
     return;
   }
 

--- a/src/translate.test.ts
+++ b/src/translate.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { translateRequest, translateResponse, createWsEventProcessor } from "./translate.js";
+import { translateRequest, translateResponse, createWsEventProcessor, TranslationError } from "./translate.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -587,22 +587,28 @@ describe("translateResponse", () => {
     assert.equal(result.usage.output_tokens, 0);
   });
 
-  it("handles malformed JSON arguments gracefully (returns empty object)", () => {
-    const { response: result } = translateResponse({
-      id: "r",
-      model: "m",
-      status: "completed",
-      output: [
-        {
-          type: "function_call",
-          call_id: "call_bad",
-          name: "fn",
-          arguments: "NOT JSON",
-        },
-      ],
-      usage: { input_tokens: 0, output_tokens: 0 },
-    });
-    assert.deepEqual(result.content[0].input, {});
+  it("throws TranslationError on malformed JSON tool call arguments", () => {
+    assert.throws(
+      () => translateResponse({
+        id: "r",
+        model: "m",
+        status: "completed",
+        output: [
+          {
+            type: "function_call",
+            call_id: "call_bad",
+            name: "fn",
+            arguments: "NOT JSON",
+          },
+        ],
+        usage: { input_tokens: 0, output_tokens: 0 },
+      }),
+      (err: unknown) => {
+        assert.ok(err instanceof TranslationError, "should be a TranslationError");
+        assert.match((err as Error).message, /Invalid JSON in tool call arguments/);
+        return true;
+      },
+    );
   });
 });
 

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -278,7 +278,7 @@ export function translateResponse(openaiRes: any, mapping?: WorktreeMapping | nu
           }
         }
       } else if (item.type === "function_call") {
-        const input = safeJsonParse(item.arguments);
+        const input = safeJsonParse(item.arguments, true);
         let finalInput = input;
         if (mapping) {
           const { result, rewritten } = rewriteInputPaths(input, mapping);
@@ -329,10 +329,23 @@ function toToolUseId(id: string): string {
   return `toolu_${id.replace(/^call_/, "")}`;
 }
 
-function safeJsonParse(str: string): any {
+/** Thrown when a tool-call argument string is not valid JSON.
+ *  Callers that can still fail the request should catch this and return a
+ *  translation_error response rather than silently producing {} inputs. */
+export class TranslationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TranslationError";
+  }
+}
+
+function safeJsonParse(str: string, strict?: false): any;
+function safeJsonParse(str: string, strict: true): any;
+function safeJsonParse(str: string, strict = false): any {
   try {
     return JSON.parse(str);
   } catch {
+    if (strict) throw new TranslationError(`Invalid JSON in tool call arguments: ${str.slice(0, 120)}`);
     return {};
   }
 }
@@ -522,7 +535,13 @@ function processEvent(
         if (mapping) {
           // Rewrite paths in the complete arguments, then emit as a single delta
           const rawArgs = state.toolArgBuffer.get(outputIndex) ?? data.arguments ?? "";
-          const parsed = safeJsonParse(rawArgs);
+          let parsed: any;
+          try {
+            parsed = JSON.parse(rawArgs);
+          } catch {
+            console.error(`[translate] Tool call arguments are not valid JSON (outputIndex=${outputIndex}): ${rawArgs.slice(0, 120)}`);
+            parsed = {};
+          }
           const { result: rewritten } = rewriteInputPaths(parsed, mapping);
           const rewrittenJson = JSON.stringify(rewritten);
           writeEvent("content_block_delta", {


### PR DESCRIPTION
Closes #46

Three focused commits, each independently reviewable.

## Commit 1 — Phase 1: atomic config writes + process-level serialization

**Problem:** `config.ts` did bare `read → modify → write` with no concurrency guard. Two concurrent token refreshes or admin requests could silently overwrite each other.

**Fix:**
- All write functions (`addSession`, `updateSessionToken`, `removeSession`, `setActive`, `setSessionModel`) are now `async` and serialized through a `Promise`-chain mutex (`withLock`)
- Writes go through `atomicSave`: data written to `.tmp` file, then `fs.rename()` into place — a crash mid-write never leaves truncated JSON
- All call sites in `proxy.ts` and `cli.ts` updated with `await`
- 4 new concurrent-write tests: no data loss, no corruption, no truncation under 10–20 parallel writers

## Commit 2 — Phase 2: RequestContext for per-request tracing

**Problem:** Routing decisions (`sessionName`, `routingReason`, `requestedModel`, `inferredProvider`, `chatSessionId`) were threaded as 3 separate parameters into `handleOpenAIProxy` and scattered into local variables. No way to correlate a response with the request that produced it.

**Fix:**
- `RequestContext` interface captures all routing metadata + `requestId` (UUID) + `startedAt`
- Built once in `handleProxy` after routing resolution, passed as a single `ctx` to `handleOpenAIProxy`
- Every response now carries `x-llm-request-id` for end-to-end tracing
- Test: request-id is present on every response and unique per request

## Commit 3 — Phase 3+4: unified failure semantics + admin surface

**Failure semantics:**
- `translateResponse()` throws `TranslationError` (exported) instead of silently returning `{}` when tool-call args are malformed JSON
- `handleOpenAIProxy` WS handler catches `TranslationError` → `502 translation_error` response instead of producing silently-wrong tool inputs
- Streaming path: logs `console.error` on bad args (can't abort mid-stream, but no longer silent)

**Observability:**
- `SessionObservability` gains `last_request_id` + `last_chat_session_id`, populated from `ctx` on every success/error record
- `GET /admin/sessions` response now includes `chat_session_bindings` (the full `chatSessionId → sessionName` map) — routing state is directly visible

**Tests:**
- `translateResponse` throws `TranslationError` on bad tool JSON
- `502 translation_error` on OpenAI WS malformed tool args (end-to-end)
- `/admin/sessions` includes `chat_session_bindings` after `/admin/chat-bind`

## Test summary

128 tests total, all passing (was 121 before this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)