### PR TITLE
Stabilize Claude Code + session switching workflow (#49)

### DIFF
--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -977,6 +977,81 @@ describe("failure semantics — translation_error", () => {
       await new Promise<void>((resolve, reject) => upstreamServer.close((err) => (err ? reject(err) : resolve())));
     }
   });
+
+  it("emits SSE error event on streaming TranslationError and closes stream", async () => {
+    const { once: onceEv } = await import("node:events");
+
+    const upstreamServer = createServer();
+    const upstreamWss = new WebSocketServer({ server: upstreamServer });
+
+    await onceEv(upstreamServer.listen(0, "127.0.0.1"), "listening");
+    const addr = upstreamServer.address();
+    assert.ok(addr && typeof addr === "object");
+    const upstreamUrl = `ws://127.0.0.1:${addr.port}`;
+
+    // Simulate upstream sending function_call_arguments.done with bad JSON.
+    // The worktree mapping triggers path-rewriting which parses the args and
+    // will throw TranslationError on invalid JSON.
+    upstreamWss.on("connection", (ws) => {
+      ws.on("message", () => {
+        ws.send(JSON.stringify({ type: "response.created", response: { id: "resp_1", model: "gpt-5.4" } }));
+        ws.send(JSON.stringify({
+          type: "response.output_item.added",
+          output_index: 0,
+          item: { type: "function_call", call_id: "call_abc", name: "Edit", id: "item_1" },
+        }));
+        ws.send(JSON.stringify({
+          type: "response.function_call_arguments.done",
+          output_index: 0,
+          arguments: "NOT VALID JSON {{{{",
+        }));
+      });
+    });
+
+    const proxy = createProxyServer({
+      openAIWsFactory: (_url, options) => new WebSocket(upstreamUrl, options),
+    });
+
+    const WORKTREE_SYSTEM = "Working directory: /repo/.claude/worktrees/feat\n\nAssistant instructions here.";
+
+    try {
+      await withCustomServer(proxy, async (baseUrl) => {
+        await request(baseUrl, "/admin/sessions", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ name: "gpt-stream", provider: "openai", token: "sk-test", model_override: "gpt-5.4" }),
+        });
+
+        const res = await fetch(`${baseUrl}/v1/messages`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            stream: true,
+            model: "gpt-5.4",
+            system: WORKTREE_SYSTEM,
+            messages: [{ role: "user", content: "hi" }],
+          }),
+        });
+
+        // Status 200 because headers were already sent before the error was detected
+        assert.equal(res.status, 200);
+        const body = await res.text();
+
+        // The SSE body must contain an error event
+        assert.ok(body.includes("event: error"), `expected SSE error event in body:\n${body}`);
+        const dataLines = body.split("\n").filter((l) => l.startsWith("data: "));
+        const errorData = dataLines.map((l) => {
+          try { return JSON.parse(l.slice(6)); } catch { return null; }
+        }).find((d) => d?.type === "error");
+        assert.ok(errorData, "expected a parseable error data line");
+        assert.equal(errorData.error.type, "translation_error");
+        assert.match(errorData.error.message, /not valid JSON/i);
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) => upstreamWss.close((err) => (err ? reject(err) : resolve())));
+      await new Promise<void>((resolve, reject) => upstreamServer.close((err) => (err ? reject(err) : resolve())));
+    }
+  });
 });
 
 describe("Anthropic OAuth token auto-refresh on 401", () => {

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1218,3 +1218,171 @@ describe("Anthropic OAuth token auto-refresh on 401", () => {
     });
   });
 });
+
+describe("Phase A — admission snapshot isolation", () => {
+  const MOCK_RESPONSE = JSON.stringify({
+    id: "msg_snapshot",
+    type: "message",
+    role: "assistant",
+    content: [],
+    model: "claude-opus-4-5",
+    stop_reason: "end_turn",
+    usage: { input_tokens: 1, output_tokens: 1 },
+  });
+
+  it("in-flight request uses originally routed session after admin active session changes", async () => {
+    // fetchResolvers[i] is called to unblock upstream fetch i
+    const fetchResolvers: Array<(r: Response) => void> = [];
+
+    const proxy = createProxyServer({
+      fetchImpl: async () =>
+        new Promise<Response>((resolve) => {
+          fetchResolvers.push(resolve);
+        }),
+    });
+
+    await withCustomServer(proxy, async (baseUrl) => {
+      // Add two sessions; session-a is added first → becomes active
+      await request(baseUrl, "/admin/sessions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "session-a", provider: "anthropic", token: "sk-ant-token-a" }),
+      });
+      await request(baseUrl, "/admin/sessions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "session-b", provider: "anthropic", token: "sk-ant-token-b" }),
+      });
+
+      // Start request 1 — it will block waiting for the upstream fetch
+      const pendingRequest = fetch(`${baseUrl}/v1/messages`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "claude-opus-4-5", max_tokens: 10, messages: [{ role: "user", content: "hi" }] }),
+      });
+
+      // Wait until the proxy has started the upstream fetch (resolver pushed)
+      await new Promise<void>((resolve) => {
+        const poll = setInterval(() => {
+          if (fetchResolvers.length >= 1) { clearInterval(poll); resolve(); }
+        }, 5);
+      });
+
+      // Switch active session while request 1 is in-flight
+      await request(baseUrl, "/admin/switch/session-b", { method: "POST" });
+
+      // Unblock request 1's upstream fetch
+      fetchResolvers[0](new Response(MOCK_RESPONSE, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }));
+
+      const r1 = await pendingRequest;
+      // Request 1 was admitted when session-a was active → must stay on session-a
+      assert.equal(r1.headers.get("x-llm-session-used"), "session-a");
+      assert.equal(r1.headers.get("x-llm-routing-reason"), "active_session_fallback");
+
+      // Request 2, started after the switch, must use session-b.
+      // Start it, wait for its upstream fetch to block, then unblock it.
+      const pendingRequest2 = fetch(`${baseUrl}/v1/messages`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "claude-opus-4-5", max_tokens: 10, messages: [{ role: "user", content: "hi" }] }),
+      });
+      await new Promise<void>((resolve) => {
+        const poll = setInterval(() => {
+          if (fetchResolvers.length >= 2) { clearInterval(poll); resolve(); }
+        }, 5);
+      });
+      fetchResolvers[1](new Response(MOCK_RESPONSE, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }));
+      const r2 = await pendingRequest2;
+      assert.equal(r2.headers.get("x-llm-session-used"), "session-b");
+    });
+  });
+
+  it("token refresh on one session does not alter the token used by a concurrent request to a different session", async () => {
+    const expiredToken = "sk-ant-oat01-expired-session-a";
+    const freshToken = "sk-ant-oat01-fresh-session-a";
+    const validToken = "sk-ant-api03-session-b-valid";
+
+    const usedTokens: string[] = [];
+
+    // Hold session-a's retry until we've confirmed session-b has completed
+    let resolveSniff!: () => void;
+    const sniffGate = new Promise<void>((r) => { resolveSniff = r; });
+
+    const proxy = createProxyServer({
+      fetchImpl: async (_url, init) => {
+        const headers = (init?.headers as Record<string, string>) ?? {};
+        // OAuth tokens → Authorization: Bearer <token>; API keys → x-api-key: <token>
+        const auth = headers.authorization ?? "";
+        const apiKey = headers["x-api-key"] ?? "";
+        const token = auth.startsWith("Bearer ") ? auth.slice(7) : apiKey;
+        if (token === expiredToken) {
+          return new Response(JSON.stringify({ error: { type: "auth_error" } }), {
+            status: 401,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        usedTokens.push(token);
+        return new Response(MOCK_RESPONSE, {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+      sniffOAuthTokenImpl: async () => {
+        // Gate: wait until the test signals session-b has completed
+        await sniffGate;
+        return freshToken;
+      },
+    });
+
+    await withCustomServer(proxy, async (baseUrl) => {
+      await request(baseUrl, "/admin/sessions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "session-a", provider: "anthropic", token: expiredToken }),
+      });
+      await request(baseUrl, "/admin/sessions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "session-b", provider: "anthropic", token: validToken }),
+      });
+
+      // Fire session-a request (will hit 401 and block on sniff)
+      const reqA = request(baseUrl, "/v1/messages", {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-llm-session": "session-a" },
+        body: JSON.stringify({ model: "claude-opus-4-5", max_tokens: 10, messages: [{ role: "user", content: "A" }] }),
+      });
+
+      // Session-b request runs concurrently and should complete independently
+      const rB = await request(baseUrl, "/v1/messages", {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-llm-session": "session-b" },
+        body: JSON.stringify({ model: "claude-opus-4-5", max_tokens: 10, messages: [{ role: "user", content: "B" }] }),
+      });
+      assert.equal(rB.status, 200);
+      assert.equal(rB.headers.get("x-llm-session-used"), "session-b");
+
+      // Unblock session-a's sniff now that session-b has finished
+      resolveSniff();
+      const rA = await reqA;
+      assert.equal(rA.status, 200);
+      assert.equal(rA.headers.get("x-llm-session-used"), "session-a");
+
+      // session-b must have used its own validToken, not session-a's freshToken
+      const bToken = usedTokens.find((t) => t === validToken);
+      const aToken = usedTokens.find((t) => t === freshToken);
+      assert.ok(bToken, "session-b should have used its own valid token");
+      assert.ok(aToken, "session-a should have retried with the fresh token");
+      assert.ok(
+        !usedTokens.some((t) => t === freshToken && usedTokens.indexOf(t) < usedTokens.indexOf(validToken)),
+        "session-a fresh token must not have been used before session-b completed",
+      );
+    });
+  });
+});

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -49,12 +49,15 @@ interface RequestContext {
   readonly resolvedSession: string | null;
   readonly inferredProvider: Session["provider"] | null;
   readonly startedAt: number;
+  /** Worktree path mapping detected at admission time; null when not a worktree request. */
+  readonly worktreeMapping: { readonly original: string; readonly worktree: string } | null;
 }
 
 function buildRequestContext(
   chatSessionId: string | null,
   session: { name: string },
   resolution: RoutingResolution,
+  worktreeMapping: { original: string; worktree: string } | null,
 ): RequestContext {
   return {
     requestId: randomUUID(),
@@ -65,6 +68,7 @@ function buildRequestContext(
     resolvedSession: resolution.resolvedSessionName,
     inferredProvider: resolution.inferredProvider,
     startedAt: Date.now(),
+    worktreeMapping,
   };
 }
 
@@ -607,7 +611,11 @@ async function handleProxy(
     return;
   }
 
-  const ctx = buildRequestContext(chatSessionId, session, resolution);
+  // Freeze the session snapshot at admission time so no downstream code can
+  // silently mutate it (e.g. token refresh must not alter the admitted state).
+  Object.freeze(session);
+  const worktreeMapping = getWorktreeMapping(chatSessionId, body.system);
+  const ctx = buildRequestContext(chatSessionId, session, resolution, worktreeMapping);
   const routingHeaders = buildResponseHeaders(ctx);
   const routingData = getRoutingReasonData(resolution);
 
@@ -671,8 +679,9 @@ async function handleProxy(
         const newToken = await refreshPromise;
         if (!newToken) throw new Error("sniffOAuthToken returned null — claude CLI unavailable or not logged in");
         await updateSessionToken(session.name, newToken);
-        session.token = newToken;
-        // Re-inject billing header with the new token before retrying
+        // Re-inject billing header with the new token before retrying.
+        // Do NOT mutate session (it is frozen at admission time); newToken is
+        // passed explicitly to doAnthropicFetch instead.
         body = injectBillingHeader({ ...body }, newToken);
         console.error(`[Anthropic] Token refreshed, retrying`);
         return doAnthropicFetch(newToken, false);
@@ -773,7 +782,8 @@ async function handleOpenAIProxy(
     return;
   }
 
-  const worktreeMapping = getWorktreeMapping(ctx.chatSessionId, requestBody.system);
+  // Worktree mapping was snapshotted at admission time and stored in ctx.
+  const worktreeMapping = ctx.worktreeMapping;
 
   const translatedBody = JSON.parse(translated.body);
   const isStream = requestBody.stream === true;
@@ -909,8 +919,8 @@ async function handleOpenAIProxy(
             const result = await refreshPromise;
             await updateSessionToken(session.name, result.access_token);
             updateCodexAuthFile(result);
-            session.token = result.access_token;
-            if (result.refresh_token) session.refresh_token = result.refresh_token;
+            // Do NOT mutate session (it is frozen at admission time); the new
+            // token is passed directly to connectWs instead.
             console.error(`[OpenAI] Token refreshed, retrying`);
             connectWs(result.access_token, false);
             return;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -851,7 +851,27 @@ async function handleOpenAIProxy(
       }
 
       if (isStream) {
-        processWsEvent(event, writeSSE);
+        try {
+          processWsEvent(event, writeSSE);
+        } catch (translateErr) {
+          const msg = translateErr instanceof TranslationError
+            ? translateErr.message
+            : `Unexpected translation error: ${(translateErr as Error).message}`;
+          console.error(`[OpenAI] Streaming translation error: ${msg}`);
+          recordSessionError(session, {
+            requestedModel,
+            effectiveModel,
+            ...routingData,
+            type: "translation_error",
+            message: msg,
+            ctx,
+          });
+          writeSSE("error", { type: "error", error: { type: "translation_error", message: msg } });
+          responseDone = true;
+          res.end();
+          ws.close();
+          return;
+        }
         if (event.type === "response.completed") {
           recordSessionSuccess(session, {
             requestedModel,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -243,6 +243,7 @@ export function resetRuntimeObservability(): void {
   for (const key of Object.keys(rateLimits)) delete rateLimits[key];
   for (const key of Object.keys(sessionObservability)) delete sessionObservability[key];
   for (const key of Object.keys(sessionProbeStatus)) delete sessionProbeStatus[key];
+  for (const key of Object.keys(chatSessionMap)) delete chatSessionMap[key];
   pendingTokenRefresh.clear();
   pendingAnthropicRefresh.clear();
   worktreeMappings.clear();
@@ -490,6 +491,20 @@ function resolveHttpRouting(req: IncomingMessage, body: any, chatSessionId: stri
     };
   }
 
+  // chat_binding_fallback takes priority over model-based routing so that
+  // switching sessions mid-chat (via /admin/chat-bind) is respected even when
+  // the request body carries a model that would otherwise match a different session.
+  const chatBoundSession = chatSessionId ? chatSessionMap[chatSessionId] : undefined;
+  if (chatBoundSession) {
+    return {
+      requestedSession: chatBoundSession,
+      requestedModel: typeof body.model === "string" && body.model.trim() ? body.model.trim() : null,
+      resolvedSessionName: chatBoundSession,
+      inferredProvider: null,
+      reason: "chat_binding_fallback",
+    };
+  }
+
   const modelResolution = resolveModelRoutedSession(body.model);
   if (modelResolution.reason === "model_override_exact" || modelResolution.reason === "session_name_alias") {
     return {
@@ -498,17 +513,6 @@ function resolveHttpRouting(req: IncomingMessage, body: any, chatSessionId: stri
       resolvedSessionName: modelResolution.resolvedSessionName,
       inferredProvider: modelResolution.inferredProvider,
       reason: modelResolution.reason,
-    };
-  }
-
-  const chatBoundSession = chatSessionId ? chatSessionMap[chatSessionId] : undefined;
-  if (chatBoundSession) {
-    return {
-      requestedSession: chatBoundSession,
-      requestedModel: modelResolution.requestedModel,
-      resolvedSessionName: chatBoundSession,
-      inferredProvider: modelResolution.inferredProvider,
-      reason: "chat_binding_fallback",
     };
   }
 

--- a/src/routing-priority.test.ts
+++ b/src/routing-priority.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Routing priority matrix tests.
+ *
+ * Priority order (highest → lowest):
+ *   explicit_session_header
+ *   explicit_session_header_compat
+ *   chat_binding_fallback      ← promoted above model-based routing in #49
+ *   model_override_exact
+ *   session_name_alias
+ *   active_session_fallback
+ *   provider_inference_match
+ */
+
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { once } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { saveConfig } from "./config.js";
+import { createProxyServer, resetRuntimeObservability } from "./proxy.js";
+
+const tempDirs: string[] = [];
+
+const MOCK_ANTHROPIC_RESPONSE = JSON.stringify({
+  id: "msg_test",
+  type: "message",
+  role: "assistant",
+  model: "claude-sonnet-4-5",
+  content: [{ type: "text", text: "ok" }],
+  stop_reason: "end_turn",
+  usage: { input_tokens: 1, output_tokens: 1 },
+});
+
+function makeMockProxy() {
+  return createProxyServer({
+    fetchImpl: async () =>
+      new Response(MOCK_ANTHROPIC_RESPONSE, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+  });
+}
+
+async function withServer(
+  fn: (baseUrl: string) => Promise<void>,
+): Promise<void> {
+  const proxy = makeMockProxy();
+  await once(proxy.listen(0, "127.0.0.1"), "listening");
+  const addr = proxy.address();
+  assert.ok(addr && typeof addr === "object");
+  const baseUrl = `http://127.0.0.1:${addr.port}`;
+  try {
+    await fn(baseUrl);
+  } finally {
+    await new Promise<void>((resolve, reject) =>
+      proxy.close((err) => (err ? reject(err) : resolve())),
+    );
+  }
+}
+
+async function adminPost(baseUrl: string, path: string, body: unknown) {
+  const res = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return res;
+}
+
+async function addSession(
+  baseUrl: string,
+  name: string,
+  opts: { model_override?: string; provider?: string } = {},
+) {
+  await adminPost(baseUrl, "/admin/sessions", {
+    name,
+    provider: opts.provider ?? "anthropic",
+    token: "sk-ant-test",
+    ...(opts.model_override ? { model_override: opts.model_override } : {}),
+  });
+}
+
+async function bindChat(
+  baseUrl: string,
+  chatSessionId: string,
+  sessionName: string,
+) {
+  await fetch(
+    `${baseUrl}/admin/chat-bind/${encodeURIComponent(chatSessionId)}/${encodeURIComponent(sessionName)}`,
+    { method: "POST" },
+  );
+}
+
+async function sendMessage(
+  baseUrl: string,
+  opts: {
+    model?: string;
+    sessionHeader?: string;
+    sessionHeaderCompat?: string;
+    chatSessionId?: string;
+  } = {},
+) {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (opts.sessionHeader) headers["x-llm-session"] = opts.sessionHeader;
+  if (opts.sessionHeaderCompat)
+    headers["x-llm-switch-session"] = opts.sessionHeaderCompat;
+  if (opts.chatSessionId)
+    headers["x-claude-code-session-id"] = opts.chatSessionId;
+
+  const res = await fetch(`${baseUrl}/v1/messages`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      model: opts.model ?? "claude-sonnet-4-5",
+      max_tokens: 10,
+      messages: [{ role: "user", content: "hi" }],
+    }),
+  });
+  return {
+    status: res.status,
+    reason: res.headers.get("x-llm-routing-reason"),
+    session: res.headers.get("x-llm-session-used"),
+  };
+}
+
+beforeEach(() => {
+  const dir = mkdtempSync(join(tmpdir(), "llm-switcher-routing-test-"));
+  tempDirs.push(dir);
+  process.env.LLM_SWITCHER_CONFIG_PATH = join(dir, "config.json");
+  saveConfig({ active_session: null, sessions: {} });
+  resetRuntimeObservability();
+});
+
+afterEach(() => {
+  delete process.env.LLM_SWITCHER_CONFIG_PATH;
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("routing priority matrix", () => {
+  it("explicit_session_header beats chat_binding_fallback", async () => {
+    await withServer(async (baseUrl) => {
+      await addSession(baseUrl, "session-a");
+      await addSession(baseUrl, "session-b");
+      await bindChat(baseUrl, "chat-1", "session-b");
+
+      const r = await sendMessage(baseUrl, {
+        sessionHeader: "session-a",
+        chatSessionId: "chat-1",
+      });
+      assert.equal(r.status, 200);
+      assert.equal(r.reason, "explicit_session_header");
+      assert.equal(r.session, "session-a");
+    });
+  });
+
+  it("explicit_session_header beats model_override_exact", async () => {
+    await withServer(async (baseUrl) => {
+      await addSession(baseUrl, "session-a");
+      await addSession(baseUrl, "session-b", { model_override: "gpt-4o" });
+
+      const r = await sendMessage(baseUrl, {
+        model: "gpt-4o",
+        sessionHeader: "session-a",
+      });
+      assert.equal(r.status, 200);
+      assert.equal(r.reason, "explicit_session_header");
+      assert.equal(r.session, "session-a");
+    });
+  });
+
+  it("explicit_session_header_compat beats chat_binding_fallback", async () => {
+    await withServer(async (baseUrl) => {
+      await addSession(baseUrl, "session-a");
+      await addSession(baseUrl, "session-b");
+      await bindChat(baseUrl, "chat-1", "session-b");
+
+      const r = await sendMessage(baseUrl, {
+        sessionHeaderCompat: "session-a",
+        chatSessionId: "chat-1",
+      });
+      assert.equal(r.status, 200);
+      assert.equal(r.reason, "explicit_session_header_compat");
+      assert.equal(r.session, "session-a");
+    });
+  });
+
+  it("chat_binding_fallback beats model_override_exact", async () => {
+    await withServer(async (baseUrl) => {
+      await addSession(baseUrl, "session-a");
+      await addSession(baseUrl, "session-b", { model_override: "gpt-4o" });
+      await bindChat(baseUrl, "chat-1", "session-a");
+
+      // body carries model=gpt-4o which would match session-b via model_override_exact,
+      // but the chat binding to session-a must win
+      const r = await sendMessage(baseUrl, {
+        model: "gpt-4o",
+        chatSessionId: "chat-1",
+      });
+      assert.equal(r.status, 200);
+      assert.equal(r.reason, "chat_binding_fallback");
+      assert.equal(r.session, "session-a");
+    });
+  });
+
+  it("chat_binding_fallback beats session_name_alias", async () => {
+    await withServer(async (baseUrl) => {
+      await addSession(baseUrl, "session-a");
+      await addSession(baseUrl, "session-b");
+      await bindChat(baseUrl, "chat-1", "session-a");
+
+      // model="session-b" would match session_name_alias, but chat binding wins
+      const r = await sendMessage(baseUrl, {
+        model: "session-b",
+        chatSessionId: "chat-1",
+      });
+      assert.equal(r.status, 200);
+      assert.equal(r.reason, "chat_binding_fallback");
+      assert.equal(r.session, "session-a");
+    });
+  });
+
+  it("chat_binding_fallback beats active_session_fallback", async () => {
+    await withServer(async (baseUrl) => {
+      await addSession(baseUrl, "session-active");
+      await addSession(baseUrl, "session-bound");
+      // make session-active the active session
+      await fetch(`${baseUrl}/admin/sessions/session-active/activate`, {
+        method: "POST",
+      });
+      await bindChat(baseUrl, "chat-1", "session-bound");
+
+      const r = await sendMessage(baseUrl, { chatSessionId: "chat-1" });
+      assert.equal(r.status, 200);
+      assert.equal(r.reason, "chat_binding_fallback");
+      assert.equal(r.session, "session-bound");
+    });
+  });
+
+  it("model_override_exact beats session_name_alias", async () => {
+    await withServer(async (baseUrl) => {
+      // session-b exists (session_name_alias candidate for model="session-b")
+      // session-a has model_override="session-b" (exact match wins)
+      await addSession(baseUrl, "session-a", { model_override: "session-b" });
+      await addSession(baseUrl, "session-b");
+
+      const r = await sendMessage(baseUrl, { model: "session-b" });
+      assert.equal(r.status, 200);
+      assert.equal(r.reason, "model_override_exact");
+      assert.equal(r.session, "session-a");
+    });
+  });
+
+  it("model_override_exact beats active_session_fallback", async () => {
+    await withServer(async (baseUrl) => {
+      await addSession(baseUrl, "session-active");
+      await fetch(`${baseUrl}/admin/sessions/session-active/activate`, {
+        method: "POST",
+      });
+      await addSession(baseUrl, "session-override", {
+        model_override: "gpt-4o",
+      });
+
+      const r = await sendMessage(baseUrl, { model: "gpt-4o" });
+      assert.equal(r.status, 200);
+      assert.equal(r.reason, "model_override_exact");
+      assert.equal(r.session, "session-override");
+    });
+  });
+
+  it("session_name_alias beats active_session_fallback", async () => {
+    await withServer(async (baseUrl) => {
+      await addSession(baseUrl, "session-active");
+      await fetch(`${baseUrl}/admin/sessions/session-active/activate`, {
+        method: "POST",
+      });
+      await addSession(baseUrl, "session-named");
+
+      const r = await sendMessage(baseUrl, { model: "session-named" });
+      assert.equal(r.status, 200);
+      assert.equal(r.reason, "session_name_alias");
+      assert.equal(r.session, "session-named");
+    });
+  });
+
+  it("active_session_fallback beats provider_inference_match", async () => {
+    await withServer(async (baseUrl) => {
+      await addSession(baseUrl, "session-active", { provider: "anthropic" });
+      await fetch(`${baseUrl}/admin/sessions/session-active/activate`, {
+        method: "POST",
+      });
+
+      // claude-opus-4-5 would match provider_inference_match for anthropic,
+      // but since there is an active session it should win as active_session_fallback
+      const r = await sendMessage(baseUrl, { model: "claude-opus-4-5" });
+      assert.equal(r.status, 200);
+      assert.equal(r.reason, "active_session_fallback");
+      assert.equal(r.session, "session-active");
+    });
+  });
+
+  it("no chat binding for a different chat session id does not interfere", async () => {
+    await withServer(async (baseUrl) => {
+      await addSession(baseUrl, "session-a");
+      await addSession(baseUrl, "session-b");
+      await fetch(`${baseUrl}/admin/sessions/session-a/activate`, {
+        method: "POST",
+      });
+      await bindChat(baseUrl, "chat-other", "session-b");
+
+      // chat-1 has no binding → should fall back to active session
+      const r = await sendMessage(baseUrl, { chatSessionId: "chat-1" });
+      assert.equal(r.status, 200);
+      assert.equal(r.reason, "active_session_fallback");
+      assert.equal(r.session, "session-a");
+    });
+  });
+});

--- a/src/routing-priority.test.ts
+++ b/src/routing-priority.test.ts
@@ -229,7 +229,7 @@ describe("routing priority matrix", () => {
       await addSession(baseUrl, "session-active");
       await addSession(baseUrl, "session-bound");
       // make session-active the active session
-      await fetch(`${baseUrl}/admin/sessions/session-active/activate`, {
+      await fetch(`${baseUrl}/admin/switch/session-active`, {
         method: "POST",
       });
       await bindChat(baseUrl, "chat-1", "session-bound");
@@ -258,7 +258,7 @@ describe("routing priority matrix", () => {
   it("model_override_exact beats active_session_fallback", async () => {
     await withServer(async (baseUrl) => {
       await addSession(baseUrl, "session-active");
-      await fetch(`${baseUrl}/admin/sessions/session-active/activate`, {
+      await fetch(`${baseUrl}/admin/switch/session-active`, {
         method: "POST",
       });
       await addSession(baseUrl, "session-override", {
@@ -275,7 +275,7 @@ describe("routing priority matrix", () => {
   it("session_name_alias beats active_session_fallback", async () => {
     await withServer(async (baseUrl) => {
       await addSession(baseUrl, "session-active");
-      await fetch(`${baseUrl}/admin/sessions/session-active/activate`, {
+      await fetch(`${baseUrl}/admin/switch/session-active`, {
         method: "POST",
       });
       await addSession(baseUrl, "session-named");
@@ -290,7 +290,7 @@ describe("routing priority matrix", () => {
   it("active_session_fallback beats provider_inference_match", async () => {
     await withServer(async (baseUrl) => {
       await addSession(baseUrl, "session-active", { provider: "anthropic" });
-      await fetch(`${baseUrl}/admin/sessions/session-active/activate`, {
+      await fetch(`${baseUrl}/admin/switch/session-active`, {
         method: "POST",
       });
 

--- a/src/translate.test.ts
+++ b/src/translate.test.ts
@@ -1045,6 +1045,57 @@ describe("translateResponse with worktree mapping", () => {
     const toolBlock = result.content.find((b: any) => b.type === "tool_use");
     assert.equal(toolBlock.input.file_path, "/Users/x/project/src/foo.ts");
   });
+
+  it("rewrites command field path tokens in Bash tool calls", () => {
+    const openaiRes = {
+      id: "r_bash",
+      model: "gpt-5.4",
+      status: "completed",
+      output: [
+        {
+          type: "function_call",
+          call_id: "call_bash",
+          name: "Bash",
+          arguments: JSON.stringify({
+            command: "grep -r foo /Users/x/project/src && ls /Users/x/project",
+          }),
+        },
+      ],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    };
+
+    const { response: result, pathRewritten } = translateResponse(openaiRes, MAPPING);
+    const toolBlock = result.content.find((b: any) => b.type === "tool_use");
+    assert.ok(toolBlock);
+    assert.equal(
+      toolBlock.input.command,
+      "grep -r foo /Users/x/project/.claude/worktrees/agent-abc/src && ls /Users/x/project/.claude/worktrees/agent-abc",
+    );
+    assert.ok(pathRewritten);
+  });
+
+  it("does not rewrite command paths already in the worktree", () => {
+    const alreadyWorktree = "cat /Users/x/project/.claude/worktrees/agent-abc/src/foo.ts";
+    const openaiRes = {
+      id: "r_bash2",
+      model: "gpt-5.4",
+      status: "completed",
+      output: [
+        {
+          type: "function_call",
+          call_id: "call_bash2",
+          name: "Bash",
+          arguments: JSON.stringify({ command: alreadyWorktree }),
+        },
+      ],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    };
+
+    const { response: result, pathRewritten } = translateResponse(openaiRes, MAPPING);
+    const toolBlock = result.content.find((b: any) => b.type === "tool_use");
+    assert.equal(toolBlock.input.command, alreadyWorktree);
+    assert.ok(!pathRewritten);
+  });
 });
 
 describe("createWsEventProcessor with worktree mapping", () => {
@@ -1091,5 +1142,54 @@ describe("createWsEventProcessor with worktree mapping", () => {
     assert.equal(argDeltas.length, 2);
     assert.equal(argDeltas[0].data.delta.partial_json, '{"file_path"');
     assert.equal(argDeltas[1].data.delta.partial_json, ':"x"}');
+  });
+
+  it("rewrites command field path tokens in Bash tool calls", () => {
+    const processor = createWsEventProcessor(MAPPING);
+    const events = collectEvents(processor, [
+      { type: "response.created", response: { id: "r6", model: "gpt-5.4" } },
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: { type: "function_call", call_id: "call_6", name: "Bash" },
+      },
+      {
+        type: "response.function_call_arguments.done",
+        output_index: 0,
+        arguments: JSON.stringify({ command: "cat /Users/x/project/src/foo.ts && echo done" }),
+      },
+    ]);
+
+    const argDeltas = events.filter(
+      (e) => e.event === "content_block_delta" && e.data.delta.type === "input_json_delta",
+    );
+    assert.equal(argDeltas.length, 1);
+    const emitted = JSON.parse(argDeltas[0].data.delta.partial_json);
+    assert.equal(emitted.command, "cat /Users/x/project/.claude/worktrees/agent-abc/src/foo.ts && echo done");
+  });
+
+  it("does not double-rewrite already-worktree command paths", () => {
+    const processor = createWsEventProcessor(MAPPING);
+    const alreadyWorktree = "cat /Users/x/project/.claude/worktrees/agent-abc/src/foo.ts";
+    const events = collectEvents(processor, [
+      { type: "response.created", response: { id: "r7", model: "gpt-5.4" } },
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: { type: "function_call", call_id: "call_7", name: "Bash" },
+      },
+      {
+        type: "response.function_call_arguments.done",
+        output_index: 0,
+        arguments: JSON.stringify({ command: alreadyWorktree }),
+      },
+    ]);
+
+    const argDeltas = events.filter(
+      (e) => e.event === "content_block_delta" && e.data.delta.type === "input_json_delta",
+    );
+    assert.equal(argDeltas.length, 1);
+    const emitted = JSON.parse(argDeltas[0].data.delta.partial_json);
+    assert.equal(emitted.command, alreadyWorktree, "already-worktree path must not be double-rewritten");
   });
 });

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -539,8 +539,7 @@ function processEvent(
           try {
             parsed = JSON.parse(rawArgs);
           } catch {
-            console.error(`[translate] Tool call arguments are not valid JSON (outputIndex=${outputIndex}): ${rawArgs.slice(0, 120)}`);
-            parsed = {};
+            throw new TranslationError(`Tool call arguments are not valid JSON (outputIndex=${outputIndex}): ${rawArgs.slice(0, 120)}`);
           }
           const { result: rewritten } = rewriteInputPaths(parsed, mapping);
           const rewrittenJson = JSON.stringify(rewritten);

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -246,6 +246,27 @@ function translateToolChoice(choice: any): any {
 
 const PATH_FIELDS = ["file_path", "path"];
 
+/**
+ * Rewrite absolute path tokens in a Bash `command` string.
+ *
+ * Uses a negative-lookahead regex so that paths already inside the worktree
+ * (`mapping.original + mapping.worktree_suffix + /`) are left untouched while
+ * bare `mapping.original/...` occurrences are promoted to the worktree path.
+ *
+ * Conservative by design: only rewrites tokens that are immediately followed
+ * by `/`, so partial prefix matches (e.g. `/repo2/`) are never affected.
+ */
+function rewriteCommandTokens(command: string, mapping: WorktreeMapping): string {
+  const esc = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  // worktree = original + suffix, e.g. "/repo" + "/.claude/worktrees/feat"
+  const suffix = mapping.worktree.slice(mapping.original.length); // "/.claude/worktrees/feat"
+  // Match mapping.original NOT already followed by the worktree suffix.
+  // The trailing lookahead accepts / (sub-path), whitespace, common shell delimiters,
+  // or end-of-string so that partial-prefix matches (/repo2/) are never rewritten.
+  const re = new RegExp(`${esc(mapping.original)}(?!${esc(suffix)})(?=[/\\s'";&|]|$)`, "g");
+  return command.replace(re, mapping.worktree);
+}
+
 function rewriteInputPaths(input: any, mapping: WorktreeMapping): { result: any; rewritten: boolean } {
   if (!input || typeof input !== "object") return { result: input, rewritten: false };
   const result = { ...input };
@@ -257,6 +278,13 @@ function rewriteInputPaths(input: any, mapping: WorktreeMapping): { result: any;
       !result[field].startsWith(mapping.worktree + "/")
     ) {
       result[field] = mapping.worktree + result[field].slice(mapping.original.length);
+      rewritten = true;
+    }
+  }
+  if (typeof result.command === "string" && result.command.includes(mapping.original + "/")) {
+    const rewrittenCmd = rewriteCommandTokens(result.command, mapping);
+    if (rewrittenCmd !== result.command) {
+      result.command = rewrittenCmd;
       rewritten = true;
     }
   }


### PR DESCRIPTION
Closes #49.

Four commits, one per phase:

## Phase B — routing priority matrix + chat binding promotion

`chat_binding_fallback` is now checked **before** `model_override_exact` / `session_name_alias`, so an explicit session switch via `/admin/chat-bind` is always respected even when the request body carries a model string that would otherwise match a different session.

Also clears `chatSessionMap` in `resetRuntimeObservability()` for proper test isolation.

New file `src/routing-priority.test.ts` — 10-case pairwise matrix covering all 7 routing reasons in priority order.

## Phase A — admission snapshot

`Object.freeze()` the session object at admission time so no downstream handler can silently mutate the admitted state.

Removes the redundant `session.token = newToken` / `session.refresh_token = ...` mutations in both the Anthropic and OpenAI token-refresh paths (the new token is already passed explicitly to the retry call and persisted to disk).

Also snapshots the worktree mapping once in `handleProxy` (stored in `RequestContext.worktreeMapping`) instead of re-detecting it inside `handleOpenAIProxy`.

## Phase D — streaming TranslationError visibility

`translate.ts`: `createWsEventProcessor` now throws `TranslationError` when path-rewriting encounters invalid JSON in `response.function_call_arguments.done`.

`proxy.ts`: the streaming `ws.on("message")` handler wraps `processWsEvent` in try/catch, calls `recordSessionError`, emits an SSE `error` event, and closes the stream.

## Phase C — Bash command path rewriting

Extends `rewriteInputPaths` to handle the `command` field. `rewriteCommandTokens` uses a conservative regex with negative lookahead (no double-rewriting) and trailing lookahead to avoid partial-prefix matches.

## Test plan

- [x] `npm test` — 144 tests, 0 failures
- [x] Routing priority pairwise matrix (10 cases)
- [x] Streaming translation error surfaces as SSE event
- [x] Bash command path rewriting (single, multi-occurrence, no double-rewrite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)