### PR TITLE
Add bilingual README + move session details to docs/sessions.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,163 +1,71 @@
 # llm-switcher
 
 [![Test](https://github.com/fanqi1909/llm-switcher/actions/workflows/test.yml/badge.svg?branch=main&event=push)](https://github.com/fanqi1909/llm-switcher/actions/workflows/test.yml)
+&nbsp;[中文](README.zh.md)
 
 Switch Claude Code and Codex CLI backends locally without losing session context.
 
-`llm-switcher` is a local proxy for Claude Code and Codex CLI that switches between Anthropic and OpenAI-backed sessions without forcing you to restart the client or split work across multiple terminals.
+`llm-switcher` is a local proxy that sits between your AI client and the upstream provider. It gives you one local endpoint on `localhost:8411` and lets you hot-swap between Anthropic and OpenAI-backed sessions — without restarting the client or re-explaining context in a new terminal.
 
-It gives you one local endpoint on `localhost:8411` and preserves **context continuity** while you rotate between:
-
-- multiple Claude accounts
-- Claude Code and OpenAI-backed sessions
-- different Codex/OpenAI accounts
-
-When you switch, the next backend still sees the same conversation, tool results, and file context already held by the client.
-
-## Positioning
-
-`llm-switcher` is a local-first open-source LLM router for personal workflows. It turns multiple subscription-backed AI sessions into one local interface instead of trying to be a hosted API platform or a multi-tenant gateway.
-
-It is designed to:
-
-- unify multiple sessions behind one local endpoint
-- switch across providers, accounts, and models without restarting the workflow
-- support richer multi-session and future multi-lane routing
-- make routing easier to inspect with admin APIs and observability
-
-## Status
-
-`llm-switcher` is currently an **experimental but working prototype**.
-
-- Core flows are working for Claude Code -> OpenAI, Claude Code -> Anthropic, and Codex CLI -> OpenAI
-- The project is usable for real workflows, but it is **not production-hardened**
-- Protocol compatibility may need maintenance as Claude Code, Codex CLI, and upstream backends evolve
-
-## Tested Setup
-
-The current repo has been tested with:
-
-- Node.js `v25.8.1`
-- Claude Code `2.1.88`
-- Codex CLI `0.117.0`
-
-## What It Does Today
-
-### Primary use cases
-
-- **Claude Code -> Anthropic**: passthrough, including Claude OAuth sessions
-- **Claude Code -> OpenAI**: Anthropic Messages requests are translated to OpenAI Responses traffic
-- **Multiple Claude accounts**: switch between accounts without opening another terminal
-- **Codex CLI -> OpenAI**: WebSocket bridge through the same local proxy endpoint
-
-### Not supported yet
-
-- **Codex CLI -> Anthropic**
-
-That reverse translation path is not implemented yet. If you point Codex CLI at `llm-switcher`, the active session still needs to be an OpenAI/Codex-compatible one.
-
-## Support Matrix
+## What It Does
 
 | Client | Backend | Status | Notes |
 |---|---|---|---|
-| Claude Code | Anthropic | Supported | Native passthrough |
-| Claude Code | OpenAI | Supported | Translated Anthropic -> OpenAI |
+| Claude Code | Anthropic | Supported | Native passthrough, including OAuth |
+| Claude Code | OpenAI | Supported | Translated Anthropic → OpenAI |
 | Codex CLI | OpenAI | Supported | Transparent WebSocket bridge |
 | Codex CLI | Anthropic | Not yet | Reverse translation not implemented |
 
 ## Why Use This
 
-- **Keep one session alive across switches** instead of re-explaining context in another terminal
-- **Rotate Claude Pro accounts** when quota is exhausted
+- **Keep one session alive across switches** — the next backend sees the same conversation, tool results, and file context
+- **Rotate Claude Pro accounts** when quota is exhausted without breaking your workflow
 - **Compare models inside one workflow** by switching the backend instead of switching tools
 - **Keep one local endpoint** for scripts, slash commands, and client config
 
-If you just want Claude Code to delegate tasks to Codex, a plugin-style workflow such as [`openai/codex-plugin-cc`](https://github.com/openai/codex-plugin-cc) is simpler. `llm-switcher` is for the stronger requirement: transport-level switching while preserving the client session. See [docs/comparison.md](docs/comparison.md).
+If you just want Claude Code to delegate tasks to Codex, a plugin-style workflow such as [`openai/codex-plugin-cc`](https://github.com/openai/codex-plugin-cc) is simpler. `llm-switcher` is for transport-level switching that preserves the client session. See [docs/comparison.md](docs/comparison.md).
+
+## Status
+
+`llm-switcher` is an **experimental but working prototype**. It is usable for real workflows but not production-hardened. Protocol compatibility may need maintenance as Claude Code, Codex CLI, and upstream backends evolve.
+
+Tested with: Node.js `v25.8.1` · Claude Code `2.1.88` · Codex CLI `0.117.0`
 
 ## Installation
 
-`llm-switcher` is currently distributed as a Node.js CLI, not a standalone binary.
-
-Requirements:
-
-- Node.js 18 or later
-- Claude Code for Claude OAuth import
-- Codex CLI for Codex OAuth import
-
-Install from source:
-
-```bash
-npm install
-npm run build
-npm link
-```
-
-Or run directly in the repo:
-
-```bash
-npx tsx src/cli.ts <command>
-```
-
-## For Early Users
-
-If you are one of the first external users, the easiest setup today is still source install:
+Requirements: Node.js 18+, Claude Code (for OAuth import), Codex CLI (for Codex OAuth import).
 
 ```bash
 git clone git@github.com:fanqi1909/llm-switcher.git
 cd llm-switcher
-npm install
-npm run build
-npm link
-```
-
-Then do the minimal first-run flow:
-
-```bash
-llm-switcher login claude
-llm-switcher codex-login gpt-work
-llm-switcher set-model claude claude-sonnet-4-5
-llm-switcher set-model gpt-work gpt-5.4
-llm-switcher serve
-```
-
-Then point Claude Code at the proxy (one-time, per terminal or in your shell profile):
-
-```bash
-export ANTHROPIC_BASE_URL=http://localhost:8411
-```
-
-If you want Claude to expose `/llm-switch` outside this repo:
-
-```bash
-llm-switcher install-claude-command
+npm install && npm run build && npm link
 ```
 
 ## Quick Start
 
-### 1. Add sessions
-
-Import a Claude Code OAuth session:
+**1. Add sessions**
 
 ```bash
-llm-switcher login
+llm-switcher login              # import Claude Code OAuth session
+llm-switcher codex-login        # import Codex OAuth session (run `codex` first)
 ```
 
-Import a Codex OAuth session:
+Or add a session manually with an API key:
 
 ```bash
-codex
-llm-switcher codex-login
+llm-switcher add claude-work --provider anthropic --token sk-ant-...
+llm-switcher add gpt-work --provider openai --token sk-...
 ```
 
-### 2. Start the proxy
+**2. Pin models and start**
 
 ```bash
+llm-switcher set-model claude-work claude-sonnet-4-5
+llm-switcher set-model gpt-work gpt-5.4
 llm-switcher serve
 ```
 
-By default it listens on `127.0.0.1:8411`.
-
-### 3. Point your client at the proxy
+**3. Point your client at the proxy**
 
 For Claude Code:
 
@@ -166,7 +74,7 @@ export ANTHROPIC_BASE_URL=http://localhost:8411
 claude
 ```
 
-For Codex CLI, add this to `~/.codex/config.toml`:
+For Codex CLI, add to `~/.codex/config.toml`:
 
 ```toml
 [model]
@@ -177,35 +85,24 @@ name = "gpt-5.4"
 base_url = "http://localhost:8411"
 ```
 
-Optional: install `/llm-switch` as a global Claude command so it is available outside this repo:
+**4. Switch sessions**
 
 ```bash
-llm-switcher install-claude-command
-```
-
-### 4. Switch sessions
-
-```bash
-llm-switcher list
-llm-switcher models claude-work
-llm-switcher models gpt-work
-llm-switcher set-model claude-work claude-sonnet-4-5
-llm-switcher set-model gpt-work gpt-5.4
-llm-switcher model claude-work
-llm-switcher model gpt-work
 llm-switcher switch claude-work
 llm-switcher switch gpt-work
 llm-switcher status
 ```
 
-## Manual Session Setup
+Or use the `/llm-switch` command inside any Claude Code chat window to bind just that window to a session:
 
-If you do not want to import OAuth sessions, you can also add sessions manually:
+```
+/llm-switch gpt-work
+```
+
+Install it globally so it works outside this repo:
 
 ```bash
-llm-switcher add claude-work --provider anthropic --token sk-ant-...
-llm-switcher add gpt-work --provider openai --token sk-...
-llm-switcher set-model gpt-work gpt-5.4
+llm-switcher install-claude-command
 ```
 
 ## CLI Commands
@@ -218,137 +115,19 @@ llm-switcher set-model gpt-work gpt-5.4
 | `add <name> -p <provider> -t <token> [-b url] [-m model]` | Add a session manually |
 | `remove <name>` | Remove a session |
 | `list` | List all configured sessions |
+| `switch <name>` | Set the active session |
+| `status` | Show the active session and latest quota info |
 | `models [name]` | List available models for the active or named session |
 | `model [name]` | Show the configured model for the active or named session |
 | `set-model <name> <model>` | Set the configured model for a session |
-| `switch <name>` | Set the active session |
-| `status` | Show the active session and latest quota info |
 | `statusline [--json]` | Render provider-aware statusline text from Claude-style stdin JSON |
 | `install-claude-command [--dir path]` | Install `/llm-switch` into Claude's commands directory |
 
-When the proxy is running, management commands go through `http://localhost:8411/admin/*`. If it is not running, the CLI falls back to editing local config directly.
+When the proxy is running, management commands go through `http://localhost:8411/admin/*`. If not running, the CLI edits local config directly.
 
-## How Sessions Work
+## Go Further
 
-`llm-switcher` keeps a local `config.json` in the repo directory:
-
-```json
-{
-  "active_session": "codex",
-  "sessions": {
-    "codex": {
-      "provider": "openai",
-      "token": "<access token>",
-      "base_url": "https://api.openai.com",
-      "model_override": "gpt-5.4",
-      "account_id": "<chatgpt account id>"
-    },
-    "claude-work": {
-      "provider": "anthropic",
-      "token": "<access token>",
-      "base_url": "https://api.anthropic.com"
-    }
-  }
-}
-```
-
-| Field | Meaning |
-|---|---|
-| `provider` | `anthropic` or `openai` |
-| `token` | API key or OAuth access token |
-| `base_url` | Upstream base URL |
-| `model_override` | Model currently pinned for that session |
-| `account_id` | Required for Codex OAuth sessions |
-
-The first session you add becomes active by default. You can hot-swap the active session at any time.
-
-Session identity and model selection are intentionally separate:
-
-- use `login`, `codex-login`, or `add` to create the session
-- use `models [name]` to inspect the provider's available models
-- use `set-model <name> <model>` to pin one model for that session
-- use `model [name]` to check the current pinned model
-
-If a provider blocks model listing for your current token, `models [name]` falls back to a built-in provider-specific suggestion list instead of failing silently.
-
-By default, `llm-switcher` uses a **global active session**: all clients connected to the proxy share the same backend unless you override it.
-
-### Per-Chat Session Binding (Claude Code)
-
-Each Claude Code chat window carries a unique `x-claude-code-session-id` on every request. The proxy uses this to let you bind individual chat windows to different sessions — so Chat A can run Opus while Chat B runs GPT, without affecting each other.
-
-Use the `/llm-switch` Claude command inside any chat window:
-
-```
-/llm-switch opus
-/llm-switch gpt-work
-```
-
-This binds only the current window. Other windows keep whatever session they are already using.
-
-To install `/llm-switch` as a global Claude command (available outside this repo):
-
-```bash
-llm-switcher install-claude-command
-```
-
-### Scoped Session Selection (HTTP / WebSocket)
-
-For direct HTTP requests, you can also pin a session per request with a header:
-
-```http
-x-llm-session: gpt-work
-```
-
-For Codex WebSocket connections:
-
-```text
-/responses?session=gpt-work
-```
-
-Session resolution order: `x-llm-session` header → per-chat binding → global active session.
-
-`x-llm-switch-session` is still accepted as a compatibility alias, but `x-llm-session` is the preferred header going forward.
-
-For proxied HTTP requests, the response includes:
-
-```http
-x-llm-session-used: <session-name>
-```
-
-This makes it easy to verify which session actually handled a request.
-
-For Claude Code custom statusline integration, `llm-switcher statusline` reads the statusline JSON payload on stdin and resolves proxy state from the current process env before falling back to proxy-global defaults.
-
-## Architecture
-
-At a high level:
-
-```text
-Claude Code --HTTP /v1/messages--> llm-switcher --HTTPS--> Anthropic
-Claude Code --HTTP /v1/messages--> llm-switcher --WS-----> chatgpt.com/backend-api/codex/responses
-Codex CLI   --WS /responses-------> llm-switcher --WS-----> chatgpt.com/backend-api/codex/responses
-```
-
-Two important details:
-
-- When the active session is **Anthropic**, Claude Code traffic is passed through with minimal changes.
-- When the active session is **OpenAI**, Claude Code still speaks Anthropic to the proxy, and the proxy translates the request/streaming response to the OpenAI side.
-
-For implementation details, protocol mapping, and event flow, see [docs/design.md](docs/design.md). For the next internal routing abstraction for root agents and subagents, see [docs/lane-design.md](docs/lane-design.md). For statusline-specific design notes, see [docs/statusline-design.md](docs/statusline-design.md).
-
-## Current Limitations
-
-- **Codex CLI -> Anthropic is not implemented**
-- **The global active session is shared** across all clients that do not have an explicit per-chat binding or `x-llm-session` header.
-- **Claude Code -> OpenAI is a translation layer**, so some Anthropic-native features do not map perfectly
-- **`max_output_tokens`, `temperature`, and `top_p` are stripped** for the Codex backend because that backend does not support them
-- **OAuth tokens expire**, so `login` / `codex-login` may need to be re-run
-
-## Related Docs
-
-- [docs/design.md](docs/design.md) — technical design and protocol details
-- [docs/agent-guidelines.md](docs/agent-guidelines.md) — repo-wide guidance for coding agents
-- [docs/statusline-design.md](docs/statusline-design.md) — provider-agnostic statusline design for Claude/Codex
+- [docs/sessions.md](docs/sessions.md) — session config, per-chat binding, routing priority, token refresh
+- [docs/design.md](docs/design.md) — architecture, protocol mapping, and event flow
 - [docs/comparison.md](docs/comparison.md) — comparison with multiple terminals and `codex-plugin-cc`
-- [docs/oauth-api-discovery.md](docs/oauth-api-discovery.md) — notes on the Codex backend endpoint
+- [docs/statusline-design.md](docs/statusline-design.md) — provider-agnostic statusline integration

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,0 +1,133 @@
+# llm-switcher
+
+[![Test](https://github.com/fanqi1909/llm-switcher/actions/workflows/test.yml/badge.svg?branch=main&event=push)](https://github.com/fanqi1909/llm-switcher/actions/workflows/test.yml)
+&nbsp;[English](README.md)
+
+在不丢失会话上下文的情况下，本地切换 Claude Code 和 Codex CLI 的后端。
+
+`llm-switcher` 是一个运行在本地的代理，位于 AI 客户端和上游服务商之间。它在 `localhost:8411` 提供统一的本地端点，让你可以在 Anthropic 和 OpenAI 支持的 session 之间热切换——无需重启客户端，也不用在新终端重新说明上下文。
+
+## 功能概览
+
+| 客户端 | 后端 | 状态 | 说明 |
+|---|---|---|---|
+| Claude Code | Anthropic | 支持 | 原生透传，包括 OAuth |
+| Claude Code | OpenAI | 支持 | Anthropic → OpenAI 协议转换 |
+| Codex CLI | OpenAI | 支持 | 透明 WebSocket 桥接 |
+| Codex CLI | Anthropic | 暂不支持 | 反向转换尚未实现 |
+
+## 为什么用这个
+
+- **切换时保持会话连续** — 下一个后端能看到同一段对话、工具调用结果和文件上下文
+- **Claude Pro 配额耗尽时轮换账号**，不打断当前工作流
+- **在同一个工作流里对比不同模型**，切换后端而不是切换工具
+- **统一本地端点**，脚本、slash 命令和客户端配置只需维护一个地址
+
+如果你只是想让 Claude Code 把任务委托给 Codex，[`openai/codex-plugin-cc`](https://github.com/openai/codex-plugin-cc) 这类插件方案更简单。`llm-switcher` 针对的是更强的需求：在传输层完成切换并保留客户端 session。详见 [docs/comparison.md](docs/comparison.md)。
+
+## 当前状态
+
+`llm-switcher` 是一个**实验性但可用的原型**。可以用于真实工作流，但尚未经过生产加固。随着 Claude Code、Codex CLI 和上游后端的更新，协议兼容性可能需要持续维护。
+
+测试环境：Node.js `v25.8.1` · Claude Code `2.1.88` · Codex CLI `0.117.0`
+
+## 安装
+
+环境要求：Node.js 18+、Claude Code（用于 OAuth 导入）、Codex CLI（用于 Codex OAuth 导入）。
+
+```bash
+git clone git@github.com:fanqi1909/llm-switcher.git
+cd llm-switcher
+npm install && npm run build && npm link
+```
+
+## 快速上手
+
+**1. 添加 session**
+
+```bash
+llm-switcher login              # 导入 Claude Code OAuth session
+llm-switcher codex-login        # 导入 Codex OAuth session（先运行一次 `codex`）
+```
+
+也可以用 API Key 手动添加：
+
+```bash
+llm-switcher add claude-work --provider anthropic --token sk-ant-...
+llm-switcher add gpt-work --provider openai --token sk-...
+```
+
+**2. 设置模型并启动**
+
+```bash
+llm-switcher set-model claude-work claude-sonnet-4-5
+llm-switcher set-model gpt-work gpt-5.4
+llm-switcher serve
+```
+
+**3. 将客户端指向代理**
+
+Claude Code：
+
+```bash
+export ANTHROPIC_BASE_URL=http://localhost:8411
+claude
+```
+
+Codex CLI，在 `~/.codex/config.toml` 中添加：
+
+```toml
+[model]
+provider = "openai"
+name = "gpt-5.4"
+
+[model.openai_compatible]
+base_url = "http://localhost:8411"
+```
+
+**4. 切换 session**
+
+```bash
+llm-switcher switch claude-work
+llm-switcher switch gpt-work
+llm-switcher status
+```
+
+或在任意 Claude Code 对话窗口中使用 `/llm-switch` 命令，只绑定当前窗口：
+
+```
+/llm-switch gpt-work
+```
+
+安装为全局命令（在该 repo 之外也可用）：
+
+```bash
+llm-switcher install-claude-command
+```
+
+## CLI 命令
+
+| 命令 | 说明 |
+|---|---|
+| `serve [-p port]` | 启动代理服务器 |
+| `login [name]` | 捕获最新的 Claude Code OAuth token 并保存为 session |
+| `codex-login [name]` | 从 `~/.codex/auth.json` 导入 Codex CLI OAuth token |
+| `add <name> -p <provider> -t <token> [-b url] [-m model]` | 手动添加 session |
+| `remove <name>` | 删除 session |
+| `list` | 列出所有已配置的 session |
+| `switch <name>` | 设置当前活跃 session |
+| `status` | 显示活跃 session 及最新配额信息 |
+| `models [name]` | 列出当前或指定 session 的可用模型 |
+| `model [name]` | 显示当前或指定 session 已配置的模型 |
+| `set-model <name> <model>` | 为 session 设置模型 |
+| `statusline [--json]` | 从 Claude 风格的 stdin JSON 渲染状态栏文本 |
+| `install-claude-command [--dir path]` | 将 `/llm-switch` 安装到 Claude 命令目录 |
+
+代理运行时，管理命令通过 `http://localhost:8411/admin/*` 执行。未运行时，CLI 直接编辑本地配置文件。
+
+## 深入了解
+
+- [docs/sessions.md](docs/sessions.md) — session 配置、per-chat 绑定、路由优先级、token 刷新
+- [docs/design.md](docs/design.md) — 架构、协议映射与事件流
+- [docs/comparison.md](docs/comparison.md) — 与多终端方案及 `codex-plugin-cc` 的对比
+- [docs/statusline-design.md](docs/statusline-design.md) — 状态栏集成设计

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -1,0 +1,159 @@
+# Sessions
+
+This document covers session configuration, lifecycle, and routing in `llm-switcher`.
+
+## Config File
+
+`llm-switcher` keeps a local `config.json` in the repo directory (or the path set by `LLM_SWITCHER_CONFIG_PATH`):
+
+```json
+{
+  "active_session": "codex",
+  "sessions": {
+    "codex": {
+      "provider": "openai",
+      "token": "<access token>",
+      "base_url": "https://api.openai.com",
+      "model_override": "gpt-5.4",
+      "account_id": "<chatgpt account id>"
+    },
+    "claude-work": {
+      "provider": "anthropic",
+      "token": "<access token>",
+      "base_url": "https://api.anthropic.com"
+    }
+  }
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `provider` | `anthropic` or `openai` |
+| `token` | API key or OAuth access token |
+| `base_url` | Upstream base URL (optional, defaults to provider default) |
+| `model_override` | Model pinned for that session |
+| `account_id` | Required for Codex OAuth sessions |
+
+The file is written atomically (write to `.tmp` then rename) and all mutations are serialized in-process, so it is safe to run a single proxy instance against it.
+
+## Session Lifecycle
+
+### Adding sessions
+
+Import a Claude Code OAuth session (spawns a `claude -p hi` subprocess to capture the token):
+
+```bash
+llm-switcher login [name]
+```
+
+Import a Codex OAuth session from `~/.codex/auth.json`:
+
+```bash
+codex                       # authenticate with Codex CLI first
+llm-switcher codex-login [name]
+```
+
+Add a session manually with an API key:
+
+```bash
+llm-switcher add <name> --provider anthropic --token sk-ant-...
+llm-switcher add <name> --provider openai --token sk-...
+```
+
+The first session added becomes the active session automatically.
+
+### Switching the active session
+
+```bash
+llm-switcher switch <name>
+llm-switcher status          # confirm the active session
+```
+
+### Pinning a model
+
+```bash
+llm-switcher models [name]       # list available models for the session
+llm-switcher set-model <name> <model>
+llm-switcher model [name]        # show the current pinned model
+```
+
+Session identity and model selection are intentionally separate. Switching sessions does not reset the model, and changing a model does not switch sessions.
+
+If a provider blocks model listing for your current token, `models [name]` falls back to a built-in provider-specific suggestion list instead of failing silently.
+
+### Removing a session
+
+```bash
+llm-switcher remove <name>
+```
+
+## Token Refresh
+
+**Anthropic OAuth sessions** (`sk-ant-oat01-*`): when the proxy receives a 401, it automatically re-runs `claude -p hi` to sniff a fresh token and retries the request once. If the re-sniff fails, the proxy returns 502 with `type: oauth_token_refresh_failed`.
+
+**OpenAI / Codex sessions**: when the proxy receives a 401 on a WebSocket connection, it uses the stored `refresh_token` (or reads it from `~/.codex/auth.json`) to call the Codex token refresh endpoint and reconnects. Concurrent refresh calls for the same session are deduplicated.
+
+If automatic refresh is not possible, run `llm-switcher login` or `llm-switcher codex-login` to manually import a fresh token.
+
+## Routing
+
+By default `llm-switcher` uses a **global active session**: every client connected to the proxy shares the same backend.
+
+### Session resolution order
+
+For each incoming request, the proxy resolves the session in this priority order:
+
+| Priority | Mechanism | How to use |
+|---|---|---|
+| 1 | `x-llm-session` header | Set on individual HTTP requests |
+| 2 | `x-llm-switch-session` header | Compatibility alias for `x-llm-session` |
+| 3 | Per-chat binding | Set via `/llm-switch` command or `POST /admin/chat-bind/` |
+| 4 | `model_override` exact match | Request body `model` matches a session's pinned model |
+| 5 | Session name alias | Request body `model` matches a session name exactly |
+| 6 | Global active session | The current `active_session` in config |
+| 7 | Provider inference | Request body `model` prefix matches a provider |
+
+The resolved session name is returned in the `x-llm-session-used` response header so you can verify which session handled each request.
+
+### Per-Chat Session Binding (Claude Code)
+
+Each Claude Code chat window carries a unique `x-claude-code-session-id` on every request. The proxy uses this to let you bind individual windows to different sessions — so Chat A can run Opus while Chat B runs GPT, without affecting each other.
+
+Use the `/llm-switch` Claude command inside any chat window:
+
+```
+/llm-switch claude-work
+/llm-switch gpt-work
+```
+
+This binds only the current window. Other windows keep whatever session they are already using.
+
+To install `/llm-switch` as a global Claude command (available outside this repo):
+
+```bash
+llm-switcher install-claude-command
+```
+
+The binding persists in memory for the lifetime of the proxy process. It is cleared when the proxy restarts.
+
+### Scoped Session Selection (per-request)
+
+For direct HTTP requests, pin a session for a single request with a header:
+
+```http
+x-llm-session: gpt-work
+```
+
+For Codex WebSocket connections, pass the session in the query string:
+
+```
+/responses?session=gpt-work
+```
+
+## Current Limitations
+
+- **Codex CLI → Anthropic is not implemented.** If you point Codex CLI at `llm-switcher`, the active session must be an OpenAI/Codex-compatible one.
+- **The global active session is shared** across all clients that do not have an explicit per-chat binding or `x-llm-session` header.
+- **Claude Code → OpenAI is a translation layer**, so some Anthropic-native features do not map perfectly.
+- **`max_output_tokens`, `temperature`, and `top_p` are stripped** for the Codex backend because that backend does not support them.
+- **OAuth tokens expire**, so `login` / `codex-login` may need to be re-run when automatic refresh is unavailable.


### PR DESCRIPTION
## Summary

- **README.md** trimmed from 354 → 133 lines. Keeps: one-liner, support matrix, Why Use This, condensed Install + Quick Start, CLI commands table, and Go Further links.
- **README.zh.md** (new): Chinese mirror with the same structure. Language toggle links at the top of each file (`[中文]` / `[English]`).
- **docs/sessions.md** (new): consolidates session technical content moved out of README — config.json structure, session lifecycle, token refresh, per-chat binding, routing priority table, current limitations.

## Test plan

- [ ] Click `[中文]` link in README.md on GitHub → lands on README.zh.md
- [ ] Click `[English]` link in README.zh.md → lands back on README.md
- [ ] All `docs/` links in README.md resolve to existing files
- [ ] docs/sessions.md renders cleanly on GitHub (tables, code blocks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)